### PR TITLE
feat(approval): approval.parallel 并行裁决选项——远程与桌面/Web 同时询问、先答先算

### DIFF
--- a/src/approval/router.mjs
+++ b/src/approval/router.mjs
@@ -8,6 +8,9 @@
 //  - 一次点击只授权一次操作：token 单次核销 + 账本状态机（首达采纳）
 //  - A listener never throws：整个 handler 包 try/catch，任何异常退回 next()
 //  - observe 模式只旁观：推完卡片立即 next()，桌面照常决定
+//
+// parallel 并行裁决：approvalConfig.parallel === true 时推卡后立即放行 next()，
+// 远程 bus.wait 与下游结果竞速、先答先算；缺省 false 为排他瀑布（等待期不询问桌面）。
 
 import { createEscalationChain } from './escalation.mjs'
 import { normalizeInbound } from '../inbound/_contract.mjs'
@@ -46,7 +49,9 @@ const DEFAULT_ESCALATION_STAGES = [
  *   每项实现统一契约（channel/notifyTargets/sendApprovalCard/editResolved/sendText，
  *   见 inbound/_contract.mjs）；telegram 旧形状（notifyChatIds/editResolved(chatId,messageId,text)）也接受
  * @param {{ mode?: 'observe'|'answer', timeoutMs?: number, numberedReply?: boolean,
+ *           parallel?: boolean,
  *           escalation?: { enabled?: boolean, stages?: Array<object> } }} [deps.approvalConfig]
+ *   parallel: true：推卡后立即放行 next() 与下游结果竞速、先答先算；缺省 false 排他瀑布。
  * @param {object} [deps.logger]
  * @param {number} [deps.counterStart=随机] - 审批 key 计数器起点。生产随机化（v0.6.4：
  *   重启后 counter 归零 + 同 callId 复现会让旧卡片 token 撞新审批的 key，在 tokenSecret
@@ -334,6 +339,59 @@ export function registerApprovalHandler(deps) {
 
       if (mode !== 'answer') {
         return next() // observe：只旁观，桌面照常决定
+      }
+
+      // —— parallel 并行分支：立即放行 next()，与远程 wait 竞速、先答先算 ——
+      // 桌面先行：abandon 撤销 waiter（迟到回复已决拒收）+ terminate 防悬挂 pending；
+      // 远程先行：直接返回裁决；远程窗口先关：改交还文案，继续等桌面。安全红线不变。
+      if (approvalConfig.parallel === true) {
+        const parallelStartedAt = Date.now()
+        escalation.start(key, (_key, stage) => {
+          notifier.notifyAll({
+            title: `${request?.toolName ?? '操作'} 仍在等待批准`,
+            content: `${stage.note ?? '仍在等待批准'}（已等待 ${Math.round((Date.now() - parallelStartedAt) / 1000)}s）。\n回复 1 批准 / 2 拒绝${cardChannelNames !== '' ? `，或点击 ${cardChannelNames} 卡片按钮` : ''}。`,
+            level: stage.level ?? 'timeSensitive',
+          }, channelTypes !== null ? { channelTypes } : {}).catch(() => {})
+        })
+        const desktopAsk = Promise.resolve().then(() => next())
+        desktopAsk.catch(() => {}) // 下游结果在竞速中消费；提前挂 catch 防未处理拒绝
+        const outcome = await new Promise((resolveRace) => {
+          let done = false
+          const finish = (value) => { if (!done) { done = true; resolveRace(value) } }
+          decisionPromise.then((decision) => {
+            if (done) return
+            if (decision !== null) return finish({ kind: 'remote', decision })
+            // 远程窗口关闭（超时或会话终止）：停升级链、改卡片文案，继续等桌面
+            escalation.stop(key)
+            if (ledger.get(key)?.decision === 'terminated') {
+              void markRemoteResolved(pushedTo, '⏹ 已终止：agent 会话已结束，审批取消').catch(() => {})
+            } else {
+              ledger.resolve(key, 'timeout')
+              void markRemoteResolved(pushedTo, '⏱ 手机端等待超时：请到桌面/Web 处理（手机按钮已失效）').catch(() => {})
+            }
+          })
+          desktopAsk.then(
+            (result) => finish({ kind: 'desktop', result }),
+            (error) => {
+              // 下游应答器抛错：按无裁决处理（undefined 透传），不吞日志
+              warn(`桌面/下游应答器异常: ${error instanceof Error ? error.message : String(error)}`)
+              finish({ kind: 'desktop', result: undefined })
+            },
+          )
+        })
+        escalation.stop(key)
+        if (outcome.kind === 'remote') {
+          ledger.resolve(key, outcome.decision.decision)
+          await markRemoteResolved(pushedTo, outcome.decision.decision === OUTCOME_ALLOWED ? '✅ 已远程批准（本次）' : '❌ 已远程拒绝')
+          warn(`${key} 并行裁决：${outcome.decision.decision}（via ${outcome.decision.via}；桌面询问已先行发出，迟到操作按已决忽略）`)
+          return outcome.decision.decision
+        }
+        // 桌面/下游先行：撤销远程 waiter（迟到回复→already-resolved），账本翻终态防悬挂 pending
+        try { bus.abandon?.(key, 'desktop-first') } catch { /* waiter 不存在亦无妨 */ }
+        try { ledger.terminate(key) } catch { /* 账本失败不致命 */ }
+        warn(`${key} 桌面/下游先行裁决，远程等待已撤销`)
+        await markRemoteResolved(pushedTo, '🖥️ 已在桌面处理（手机按钮已失效）')
+        return outcome.result
       }
 
       // 升级链与 wait 并行：每到一个 stage 再推一轮更高 level 提醒

--- a/src/approval/router.mjs
+++ b/src/approval/router.mjs
@@ -187,7 +187,11 @@ export function registerApprovalHandler(deps) {
         if (alias !== undefined) merged.add(alias)
       }
       return [...merged]
-    } catch {
+    } catch (error) {
+      // P1-2 错误可见性（2026-08-20，Trae1，自上游 0.8.6 接力）：路由解析异常与
+      // 「空集」同样回落全局广播（fail-safe 投递语义不变），但异常路径原先零日志
+      // ——路由子系统坏了会无声地把审批卡广播到全渠道。
+      warn(`审批分流解析异常，回落全局广播（路由引擎报错: ${error instanceof Error ? error.message : String(error)}）`)
       return null
     }
   }

--- a/src/approval/router.mjs
+++ b/src/approval/router.mjs
@@ -266,7 +266,7 @@ export function registerApprovalHandler(deps) {
     // 判定不出出站面时（无 router 分流且 notifier 未暴露渠道表——旧式装配/测试台架）
     // 广播目标记为 null = 保持上游行为全量广播，绝不静默跳过。
     const filterDedup = (types) => types.filter((type) => {
-      if (!outboundKnown.has(type)) return false // 别名展开出的入站名（如 'qq'）不进广播
+      if (outboundKnown.size > 0 && !outboundKnown.has(type)) return false // 出站表可得时，别名展开出的入站名（如 'qq'）不进广播
       const alias = INTERACTIVE_ALIASES[String(type)]
       if (alias === undefined) return true // 无别名映射的渠道：保持上游双发行为
       return !cardedInteractive.has(alias) // 仅 qq 官方 bot：卡片已送达则跳过广播

--- a/src/approval/router.mjs
+++ b/src/approval/router.mjs
@@ -13,7 +13,7 @@
 // 远程 bus.wait 与下游结果竞速、先答先算；缺省 false 为排他瀑布（等待期不询问桌面）。
 
 import { createEscalationChain } from './escalation.mjs'
-import { normalizeInbound } from '../inbound/_contract.mjs'
+import { normalizeInbound, parseApprovalAction } from '../inbound/_contract.mjs'
 import { guardTargets } from '../inbound/target-guard.mjs'
 import { workspaceOf } from '../routing/session-registry.mjs'
 
@@ -29,6 +29,13 @@ const DISPLAY_NAMES = {
   wechat: '微信',
   dingtalk: '钉钉',
 }
+
+// 出站渠道类型 → 入站交互渠道名的显式别名表（严格逐名映射，无通配）。
+// dsh-notifier 的 QQ 只有一种实现（官方机器人），但注册了两个名字：入站交互
+// 渠道 'qq'（WS 网关）、出站通知渠道 'qq-bot'（REST）——不同适配器、不同投递面，
+// 必须严格区分。本表仅桥接这一对名字；未来若新增其他 QQ 实现（onebot/qmsg 等）
+// 各自独立注册、绝不共用别名。
+const INTERACTIVE_ALIASES = Object.freeze({ 'qq-bot': 'qq' })
 
 // 升级链默认节奏：30s / 60s 各再提醒一轮（timeoutMs 默认 120s 内完成两轮升级）
 const DEFAULT_ESCALATION_STAGES = [
@@ -167,7 +174,19 @@ export function registerApprovalHandler(deps) {
     try {
       const globalTypes = Array.isArray(notifier?.channels) ? notifier.channels : []
       const { channelTypes } = router.resolveOutbound(String(agentId), workspaceOf(request.agent), globalTypes)
-      return channelTypes
+      if (!Array.isArray(channelTypes)) return channelTypes
+      // v0.8.4 QQ 渠道别名修复：出站适配器注册名是 'qq-bot'，入站交互渠道名是 'qq'，
+      // 两者不同名（同一官方机器人实现的两个投递面，见 INTERACTIVE_ALIASES 注）。
+      // 分流结果只含出站名时 planApprovalTargets 会把 qq 交互渠道整体过滤掉——卡片
+      // 零发送、pushedTo 恒空、编号回复 intended 兜底失效（裸数字漏进会话路由，
+      // 2026-08-23 全天事故链的总根因）。这里把出站名展开为「出站名 + 别名入站名」
+      // 并入集合；广播侧未知类型由 notifyAll 自然跳过，无副作用。
+      const merged = new Set(channelTypes)
+      for (const type of channelTypes) {
+        const alias = INTERACTIVE_ALIASES[type]
+        if (alias !== undefined) merged.add(alias)
+      }
+      return [...merged]
     } catch {
       return null
     }
@@ -192,7 +211,10 @@ export function registerApprovalHandler(deps) {
 
   async function pushApproval(key, token, request, channelTypes, targetsByChannel) {
     const title = `需要批准：${request.toolName}`
-    const content = `${request.reason ?? 'agent 请求执行一个需要授权的操作'}\n\n批准将仅对本次调用生效（token 单次核销）。`
+    // v0.8.4 双端提示：并行模式下网页弹窗与远程卡片同问，远程先决时网页弹窗成为
+    // 孤儿应答（宿主 api-proxy 无「已解决」广播机制），但迟到点击被首达采纳自然
+    // 忽略、无副作用——文案明示用户可随意处置，避免等待/困惑。
+    const content = `${request.reason ?? 'agent 请求执行一个需要授权的操作'}\n\n批准将仅对本次调用生效（token 单次核销）。\n双端同问、先答先算：一处裁决后即生效，另一端的网页弹窗/卡片可随意关闭或忽略。`
     const pushedTo = []
     const buttonChannels = []
     const textChannels = []
@@ -231,6 +253,28 @@ export function registerApprovalHandler(deps) {
         else textChannels.push(name)
       }
     }
+    // v0.8.4 渠道级去重广播：广播线降级为「未收到卡片的渠道」的兜底（单向渠道、
+    // 卡片发送失败场景）。已成功收到卡片的交互渠道，其出站孪生不再重发纯文本——
+    // 严格按渠道名逐个判断（仅别名命中 carded 才抑制），不做任何跨平台归并。
+    // qq 单渠道拓扑效果：卡片必达 → 广播整体跳过，审批只发一条消息。
+    const cardedInteractive = new Set(pushedTo.map((target) => String(target?.channel ?? '')))
+    const outboundKnown = new Set(Array.isArray(notifier?.channels) ? notifier.channels : [])
+    // ⚠️ 范围声明：广播去重仅测试过 QQ 官方 bot（qq-bot ↔ qq 别名对，同一实现的
+    // 出站/入站两个注册面）。其他平台理论可行但未逐一实测，暂不启用——无别名映射的
+    // 渠道一律保持上游「卡片+广播」双发行为；后续实测一个平台，把名字对加进
+    // INTERACTIVE_ALIASES 即自动纳入去重。
+    // 判定不出出站面时（无 router 分流且 notifier 未暴露渠道表——旧式装配/测试台架）
+    // 广播目标记为 null = 保持上游行为全量广播，绝不静默跳过。
+    const filterDedup = (types) => types.filter((type) => {
+      if (!outboundKnown.has(type)) return false // 别名展开出的入站名（如 'qq'）不进广播
+      const alias = INTERACTIVE_ALIASES[String(type)]
+      if (alias === undefined) return true // 无别名映射的渠道：保持上游双发行为
+      return !cardedInteractive.has(alias) // 仅 qq 官方 bot：卡片已送达则跳过广播
+    })
+    let broadcastTargetTypes = null
+    if (Array.isArray(channelTypes)) broadcastTargetTypes = filterDedup(channelTypes)
+    else if (outboundKnown.size > 0) broadcastTargetTypes = filterDedup([...outboundKnown])
+    if (broadcastTargetTypes !== null && broadcastTargetTypes.length === 0) return pushedTo
     // 全渠道通知（含单向渠道；无按钮渠道靠编号回复降级）
     // 按钮渠道提示可点；无按钮渠道提示编号回复——单向广播渠道（bark 等）同样
     // 依赖「回复 1 批准 / 2 拒绝」兜底，因此按钮场景也保留该提示（v0.2.0 文案契约）。
@@ -243,7 +287,7 @@ export function registerApprovalHandler(deps) {
         ? `${content}\n\n（${channelNotes.join('；')}；无按钮渠道可回复 1 批准 / 2 拒绝）`
         : `${content}\n\n（本渠道无按钮：回复 1 批准 / 2 拒绝）`,
       level: 'timeSensitive',
-    }, channelTypes !== null ? { channelTypes } : {}).catch(() => {})
+    }, broadcastTargetTypes !== null ? { channelTypes: broadcastTargetTypes } : {}).catch(() => {})
     return pushedTo
   }
 
@@ -285,6 +329,68 @@ export function registerApprovalHandler(deps) {
     return true
   }
 
+  // v0.8.4 按钮裁决（QQ INTERACTION_CREATE 显式 key）：envelope.approvalAction 由
+  // qq-gw 从 button_data「ap:<decision>:<approvalKey>:<token>」（契约协议，与
+  // telegram/飞书同构）解析注入。与编号回复的本质区别：key+token 是卡片发送时写进
+  // 按钮的精确值，不做「最近待决」隐式匹配——多行并存、僵尸行、并行竞速都不会再
+  // 劫持目标（2026-08-23 事故根治）。安全链路：
+  //   WS 事件 → bus.accept 身份门（绑定/白名单）→ 此处 pushedTo 用户级校验（群内
+  //   防代点）→ bus.decide 的 HMAC token 验签 + allowChats 会话级校验 → 首达采纳。
+  function handleApprovalAction(envelope) {
+    let action = envelope?.approvalAction
+    // v0.8.4 文本形态兜底：指令按钮/旧客户端会把按钮 data 当文本消息发出（2026-08-23
+    // 实测：action.type=2 的点击以「ap:<decision>:<key>:<token>」文本到达）。能完整
+    // 解析为契约负载的文本按同一裁决路径处理；安全不变——仍过 token 验签 + 接收人 +
+    // allowChats。普通聊天几乎不可能以 ap: 开头且四段结构合法，误伤可忽略。
+    if ((action === null || action === undefined) && typeof envelope?.text === 'string' && envelope.text.startsWith('ap:')) {
+      const parsed = parseApprovalAction(envelope.text.trim())
+      if (parsed !== null) {
+        action = { decision: parsed.decision, approvalKey: parsed.approvalKey, token: parsed.token }
+        warn(`文本形态按钮负载已受理（${envelope.channel} user ${envelope.userId}）`)
+      }
+    }
+    if (action === null || typeof action !== 'object') return false
+    const key = String(action.approvalKey ?? '')
+    const decision = action.decision === OUTCOME_ALLOWED ? OUTCOME_ALLOWED
+      : action.decision === OUTCOME_REJECTED ? OUTCOME_REJECTED : null
+    if (key === '' || decision === null) return false
+    const receipt = (text) => {
+      const inbound = interactiveByChannel.get(envelope.channel)
+      if (inbound === undefined) return
+      void inbound.sendText(envelope.chatId, text).catch(() => {})
+    }
+    const row = ledger.get(key)
+    if (row === undefined || row.status !== 'pending') {
+      warn(`按钮裁决落空 ${key}（状态 ${row?.status ?? '无此行'}，user ${envelope.userId}）`)
+      receipt('该审批已被处理或已失效，此次点击无效')
+      return true
+    }
+    // 用户级校验：卡片送达记录里有明确接收人时，仅接收人可裁决（群场景防他人代点；
+    // 单聊天然匹配）。pushedTo 为空（增量落账窗口）时跳过——allowChats 仍在兜底。
+    const targets = Array.isArray(row.pushedTo) ? row.pushedTo.filter((t) => t?.channel === envelope.channel) : []
+    if (targets.length > 0 && !targets.some((t) => String(t.userId) === String(envelope.userId))) {
+      warn(`按钮裁决拒绝 ${key}：点击者 ${envelope.userId} 非接收人`)
+      receipt('仅审批接收人可点击裁决')
+      return true
+    }
+    const verdict = bus.decide({
+      approvalKey: key,
+      decision,
+      token: typeof action.token === 'string' ? action.token : undefined,
+      via: `${envelope.channel}:button`,
+      userId: envelope.userId,
+      chatId: envelope.chatId,
+    })
+    if (verdict.ok) {
+      warn(`按钮裁决 ${key} → ${decision}（user ${envelope.userId}）`)
+      return true
+    }
+    warn(`按钮裁决落空 ${key}（${verdict.reason ?? 'unknown'}，user ${envelope.userId}）`)
+    receipt('该审批已被处理或已失效，此次点击无效')
+    return true
+  }
+
+  const disposeApprovalAction = bus.onMessage(handleApprovalAction)
   const disposeMessage = bus.onMessage(handleNumberedReply)
 
   const handler = async (request, next) => {
@@ -431,6 +537,7 @@ export function registerApprovalHandler(deps) {
   const disposeApproval = ctx.on('approval/request', handler)
   return () => {
     disposeApproval?.()
+    disposeApprovalAction?.()
     disposeMessage?.()
     escalation.dispose()
   }

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -268,6 +268,9 @@ export function resolveConfig(config = {}) {
   const rawQuestions = (raw.questions !== null && typeof raw.questions === 'object') ? raw.questions : {}
   const questions = {
     enabled: rawQuestions.enabled !== false,
+    // 双端并行（2026-08-24）：工具执行即同时弹桌面 Web 弹窗 + 推远端卡片，先答先算，
+    // 与审批 parallel 同构。缺省开启；parallel:false 回落单端瀑布（旧行为）。
+    parallel: rawQuestions.parallel !== false,
     timeoutMs: typeof rawQuestions.timeoutMs === 'number' && Number.isFinite(rawQuestions.timeoutMs) && rawQuestions.timeoutMs > 0
       ? Math.trunc(rawQuestions.timeoutMs)
       : 300_000,

--- a/src/inbound/qq-gw.mjs
+++ b/src/inbound/qq-gw.mjs
@@ -19,7 +19,7 @@
 
 import { createTokenManager, createRateGate } from '../adapters/_tokens.mjs'
 import { resolveNotifyTargets } from './target-guard.mjs'
-import { buildApprovalAction, parseApprovalAction } from './_contract.mjs'
+import { buildApprovalAction, parseApprovalAction, buildQuestionAction, parseQuestionAction } from './_contract.mjs'
 
 const TOKEN_URL = 'https://bots.qq.com/app/getAppAccessToken'
 const DEFAULT_API_BASE = 'https://api.sgroup.qq.com'
@@ -274,18 +274,37 @@ export function createQqInbound(options = {}) {
         })
         targetKinds.set(chatId, chatId === userId ? 'user' : 'group')
         const parsed = parseApprovalAction(buttonData)
-        if (parsed === null) return
-        const result = bus.accept({
+        if (parsed !== null) {
+          const result = bus.accept({
+            channel: 'qq',
+            userId,
+            chatId,
+            messageId: interactionId,
+            text: `[审批按钮:${parsed.decision}] ${parsed.approvalKey}`,
+            approvalAction: { decision: parsed.decision, approvalKey: parsed.approvalKey, token: parsed.token },
+          })
+          if (result?.reply !== undefined) {
+            postMessage(chatId, String(result.reply), interactionId).catch((error) => {
+              warn(`按钮回执发送失败: ${error instanceof Error ? error.message : String(error)}`)
+            })
+          }
+          return
+        }
+        // v0.8.x 提问按钮：aq:<qKey>:<optIdx|s|c>:<token>（选项下标 / s=跳过 / c=自定义
+        // 教学）。与审批按钮同一分发面、互斥前缀；非本插件按钮静默忽略。
+        const qParsed = parseQuestionAction(buttonData)
+        if (qParsed === null) return
+        const qResult = bus.accept({
           channel: 'qq',
           userId,
           chatId,
           messageId: interactionId,
-          text: `[审批按钮:${parsed.decision}] ${parsed.approvalKey}`,
-          approvalAction: { decision: parsed.decision, approvalKey: parsed.approvalKey, token: parsed.token },
+          text: `[提问按钮:${qParsed.optIdx}] ${qParsed.qKey}`,
+          questionAction: { qKey: qParsed.qKey, optIdx: qParsed.optIdx, token: qParsed.token },
         })
-        if (result?.reply !== undefined) {
-          postMessage(chatId, String(result.reply), interactionId).catch((error) => {
-            warn(`按钮回执发送失败: ${error instanceof Error ? error.message : String(error)}`)
+        if (qResult?.reply !== undefined) {
+          postMessage(chatId, String(qResult.reply), interactionId).catch((error) => {
+            warn(`提问按钮回执发送失败: ${error instanceof Error ? error.message : String(error)}`)
           })
         }
         return
@@ -519,6 +538,50 @@ export function createQqInbound(options = {}) {
         return messageId !== null ? { messageId } : null
       } catch (error) {
         warn(`审批通知发送失败: ${error instanceof Error ? error.message : String(error)}`)
+        return null
+      }
+    },
+
+    /** 推提问卡片（v0.8 sendQuestionCard 契约实现）：markdown 选项清单 + 每项一枚
+     *  回调按钮（aq:<qKey>:<idx>:<token>，P7 载荷不带选项文本）+ 尾行「跳过/自定义」。
+     *  多选场景点按钮=单选提交（组合选择走「1,3」编号文本）；自定义回答走「答：内容」
+     *  文本前缀（按钮只作教学）。失败抛错由 normalizeInbound 归一 null → 编号兜底。 */
+    async sendQuestionCard({ chatId, title, content, qKey, token, options, multiSelect }) {
+      const opts = Array.isArray(options) ? options.map((label) => String(label)) : []
+      if (opts.length === 0) return null
+      try {
+        const isUserTarget = targetKindOf(chatId) === 'user'
+        const actionButton = (id, label, visitedLabel, style, optIdx) => ({
+          id,
+          render_data: { label, visited_label: visitedLabel, style },
+          action: {
+            type: 1,
+            ...(isUserTarget ? { permission: { type: 2, specify_user_ids: [String(chatId)] } } : {}),
+            click_limit: 1,
+            data: buildQuestionAction(qKey, optIdx, token),
+          },
+        })
+        const rows = opts.slice(0, 5).map((label, idx) => ({
+          buttons: [actionButton(`q_opt_${idx}`, `${idx + 1}. ${label.slice(0, 12)}`, '已作答', 0, String(idx))],
+        }))
+        rows.push({
+          buttons: [
+            actionButton('q_skip', '⏭ 跳过', '已跳过', 2, 's'),
+            actionButton('q_custom', '✍️ 自定义', '见说明', 0, 'c'),
+          ],
+        })
+        const markdown = [
+          title,
+          content,
+          '',
+          ...opts.map((label, idx) => `${idx + 1}. ${label}`),
+          multiSelect === true ? '（多选题：点按钮=提交单选；组合选择请回复编号如 1,3）' : '',
+          '自定义回答：回复「答：<你的回答>」',
+        ].filter((line) => line !== '').join('\n')
+        const messageId = await postMarkdownWithKeyboard(chatId, markdown, { content: { rows } })
+        return messageId !== null ? { messageId } : null
+      } catch (error) {
+        warn(`提问卡片发送失败: ${error instanceof Error ? error.message : String(error)}`)
         return null
       }
     },

--- a/src/inbound/qq-gw.mjs
+++ b/src/inbound/qq-gw.mjs
@@ -6,19 +6,25 @@
 //  - 事件：C2C_MESSAGE_CREATE（单聊）/ GROUP_AT_MESSAGE_CREATE（群 @，仅被 @ 时投递）
 //  - 网关协议：op10 HELLO → op2 IDENTIFY（或 op6 RESUME）→ op1/op11 心跳；
 //    op0 DISPATCH 携带 s 序号（心跳带回）；op7 RECONNECT / op9 INVALID_SESSION 走重连
-//  - 审批：QQ 官方机器人无通用交互按钮卡片 → capabilities.buttons = false，
-//    审批走文本通知 + 「回复 1 批准 / 2 拒绝」降级（router 已按能力分流文案）
-//  - intents 默认 GROUP_AND_C2C（1<<25）；被@/单聊事件都在这一档
+//  - 审批：v0.8.4 按钮化（2026-08 实测平台已开放 markdown+内嵌键盘）：审批卡优先
+//    msg_type=2 + keyboard 长形式（content.rows），回调按钮 action.data 携带契约
+//    协议「ap:<decision>:<approvalKey>:<token>」（与 telegram/飞书同构，HMAC 验签）；
+//    发送失败自动降级文本编号回复（能力探测免配置）
+//  - 点击回传：INTERACTION_CREATE（intent INTERACTION 1<<26）经本 WS 网关推送，
+//    收到后立即异步 PUT /interactions/{id} ACK（3s 窗口），再把显式 key 裁决送 bus.decide
+//  - intents 默认 GROUP_AND_C2C(1<<25) | INTERACTION(1<<26)；被@/单聊/按钮点击都在这两档
 // 军规：任何异常只 warn 不抛；断线指数退避重连（RESUME 优先）；stop() 清干净全部定时器。
 // 频控：Bot 维度 60qpm ≈ 1 条/秒（复用出站 qq-bot 的限速门经验值）；被动回复
 // （带 msg_id 关联事件）有独立配额，5 条内免主动消息权限。
 
 import { createTokenManager, createRateGate } from '../adapters/_tokens.mjs'
 import { resolveNotifyTargets } from './target-guard.mjs'
+import { buildApprovalAction, parseApprovalAction } from './_contract.mjs'
 
 const TOKEN_URL = 'https://bots.qq.com/app/getAppAccessToken'
 const DEFAULT_API_BASE = 'https://api.sgroup.qq.com'
 const INTENT_GROUP_AND_C2C = 1 << 25
+const INTENT_INTERACTION = 1 << 26 // INTERACTION_CREATE：消息按钮点击回调（v0.8.4 按钮化）
 
 // WS op codes（QQ 网关协议）
 const OP_DISPATCH = 0
@@ -46,7 +52,7 @@ export function resolveQqInboundConfig(raw, options = {}) {
   }
   const notifyUsers = (Array.isArray(cfg.notifyUsers) ? cfg.notifyUsers : []).map((id) => String(id).trim()).filter((id) => id !== '')
   const notifyGroups = (Array.isArray(cfg.notifyGroups) ? cfg.notifyGroups : []).map((id) => String(id).trim()).filter((id) => id !== '')
-  const intents = Number.isInteger(cfg.intents) && cfg.intents >= 0 ? cfg.intents : INTENT_GROUP_AND_C2C
+  const intents = Number.isInteger(cfg.intents) && cfg.intents >= 0 ? cfg.intents : (INTENT_GROUP_AND_C2C | INTENT_INTERACTION)
   return {
     ok: true,
     config: {
@@ -67,7 +73,17 @@ function stripMention(content) {
 }
 
 /**
- * 创建 QQ 官方机器人入站通道（统一契约；buttons=false，审批走编号回复）。
+ * 审批按钮负载（v0.8.4）：直接复用契约协议 `ap:<decision>:<approvalKey>:<token>`
+ * （buildApprovalAction/parseApprovalAction，与 telegram/feishu callback_data 完全
+ * 同构，复用同一套 HMAC token 核销）。key+token 在卡片发送时写死进按钮——点击回传
+ * 按显式 key 精确命中并验签，杜绝「最近待决」隐式匹配在多行并存/僵尸行/并行竞速下
+ * 的目标劫持（2026-08-23 事故的病根）。
+ */
+/** 解析按钮回调数据；非契约格式 → null（调用方静默忽略）。见 parseApprovalAction。 */
+
+/**
+ * 创建 QQ 官方机器人入站通道（统一契约；v0.8.4 buttons=true——审批优先按钮卡片，
+ * 发送失败自动降级文本编号回复）。
  * @param {object} options
  * @param {{ appId: string, appSecret: string, apiBase?: string, intents?: number,
  *           notifyUsers?: string[], notifyGroups?: string[], timeoutMs?: number }} options.config
@@ -242,6 +258,38 @@ export function createQqInbound(options = {}) {
         }
         return
       }
+      if (t === 'INTERACTION_CREATE') {
+        // v0.8.4 按钮回调（type=11 消息按钮）：先异步 ACK（PUT /interactions，3s 窗口，
+        // 失败只影响客户端转圈不致命），再解析 apv 载荷送 bus——显式 key 裁决，
+        // 不做任何隐式匹配；非本插件按钮静默忽略。
+        const type = Number(d?.type ?? d?.data?.type ?? 0)
+        if (type !== 11) return
+        const interactionId = String(d?.id ?? '')
+        const buttonData = String(d?.data?.resolved?.button_data ?? '')
+        const userId = String(d?.user_openid ?? d?.group_member_openid ?? '')
+        const chatId = String(d?.user_openid ?? d?.group_openid ?? '')
+        if (interactionId === '' || userId === '' || chatId === '') return
+        void ackInteraction(interactionId).catch((error) => {
+          warn(`互动 ACK 失败: ${error instanceof Error ? error.message : String(error)}`)
+        })
+        targetKinds.set(chatId, chatId === userId ? 'user' : 'group')
+        const parsed = parseApprovalAction(buttonData)
+        if (parsed === null) return
+        const result = bus.accept({
+          channel: 'qq',
+          userId,
+          chatId,
+          messageId: interactionId,
+          text: `[审批按钮:${parsed.decision}] ${parsed.approvalKey}`,
+          approvalAction: { decision: parsed.decision, approvalKey: parsed.approvalKey, token: parsed.token },
+        })
+        if (result?.reply !== undefined) {
+          postMessage(chatId, String(result.reply), interactionId).catch((error) => {
+            warn(`按钮回执发送失败: ${error instanceof Error ? error.message : String(error)}`)
+          })
+        }
+        return
+      }
     } catch (error) {
       warn(`事件处理异常: ${error instanceof Error ? error.message : String(error)}`)
     }
@@ -258,7 +306,7 @@ export function createQqInbound(options = {}) {
         op: OP_IDENTIFY,
         d: {
           token: `QQBot ${token}`,
-          intents: config.intents ?? INTENT_GROUP_AND_C2C,
+          intents: config.intents ?? (INTENT_GROUP_AND_C2C | INTENT_INTERACTION),
           shard: [0, 1],
           properties: { $os: 'dsh-notifier', $browser: 'dsh-notifier', $device: 'dsh-notifier' },
         },
@@ -346,9 +394,47 @@ export function createQqInbound(options = {}) {
     return typeof payload?.id === 'string' && payload.id !== '' ? payload.id : `qq:${target}:${seq}`
   }
 
+  /** 互动事件回执（PUT /interactions/{id}，50QPS）：3 秒窗口内告知平台已受理，
+   *  否则用户端按钮一直 loading。失败由调用方 catch（不致命）。 */
+  async function ackInteraction(interactionId) {
+    if (fetchImpl === undefined) return
+    const token = await tokens.get()
+    await fetchImpl(`${apiBase}/interactions/${encodeURIComponent(interactionId)}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json', authorization: `QQBot ${token}` },
+      body: JSON.stringify({ code: 0 }),
+    })
+  }
+
+  /** 发送 markdown + 内嵌键盘（审批按钮卡片，msg_type=2）。失败抛错，调用方降级文本。 */
+  async function postMarkdownWithKeyboard(chatId, markdownContent, keyboard) {
+    if (fetchImpl === undefined) return null
+    const token = await tokens.get()
+    await rateGate.gate()
+    const target = String(chatId)
+    const seq = (msgSeqs.get(target) ?? 0) + 1
+    msgSeqs.set(target, seq)
+    const kind = targetKindOf(target)
+    const url = kind === 'group'
+      ? `${apiBase}/v2/groups/${target}/messages`
+      : `${apiBase}/v2/users/${target}/messages`
+    const body = { msg_type: 2, msg_seq: seq, markdown: { content: String(markdownContent).slice(0, 3000) }, keyboard }
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `QQBot ${token}` },
+      body: JSON.stringify(body),
+    })
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || (typeof payload?.code === 'string' && payload.code !== '')) {
+      throw new Error(`QQ 按钮卡片发送失败（HTTP ${response.status}${payload?.code ? ` code ${payload.code}` : ''}: ${payload?.message ?? ''}）`)
+    }
+    return typeof payload?.id === 'string' && payload.id !== '' ? payload.id : `qq-kb:${target}:${seq}`
+  }
+
   return {
     channel: 'qq',
-    capabilities: { buttons: false },
+    // v0.8.4：按钮化落地（发送失败自动降级文本，capabilities 仅影响文案分流）
+    capabilities: { buttons: true },
 
     /** 启动网关连接（幂等；失败中文 warn 后允许再次 start 重试）。 */
     start() {
@@ -390,10 +476,45 @@ export function createQqInbound(options = {}) {
       })
     },
 
-    /** 推审批文本通知（无按钮，回复 1/2 裁决）；失败 null 降级纯通知。 */
-    async sendApprovalCard({ chatId, title, content }) {
-      const text = `${title}\n${content}\n\n回复 1 批准 / 2 拒绝`
+    /** 推审批通知（v0.8.4）：优先 markdown+内嵌键盘——两颗回调按钮（type 1）action.data
+     *  携带契约协议「ap:<decision>:<approvalKey>:<token>」，click_limit=1 防重复，
+     *  单聊场景 permission 锁定接收人。发送失败自动降级文本编号回复（无感切换）。 */
+    async sendApprovalCard({ chatId, title, content, approvalKey, token }) {
+      if (typeof approvalKey === 'string' && approvalKey !== '' && typeof token === 'string' && token !== '') {
+        try {
+          const isUserTarget = targetKindOf(chatId) === 'user'
+          const button = (id, label, visitedLabel, style, decision) => ({
+            id,
+            render_data: { label, visited_label: visitedLabel, style },
+            action: {
+              // type 必须 1（回调按钮：点击产生 INTERACTION_CREATE 推送到本网关）。
+              // type 2 是「指令按钮」——客户端会把 data 当文本消息自动发出，不产生
+              // 回调事件（2026-08-23 实测踩坑：官方 overview 示例的 type:2 是指令语义）。
+              type: 1,
+              ...(isUserTarget ? { permission: { type: 2, specify_user_ids: [String(chatId)] } } : {}),
+              click_limit: 1,
+              data: buildApprovalAction(decision, approvalKey, token),
+            },
+          })
+          const keyboard = {
+            content: {
+              rows: [
+                { buttons: [
+                  button('btn_approve', '✅ 批准', '已批准', 1, 'allowed-once'),
+                  button('btn_reject', '❌ 拒绝', '已拒绝', 2, 'rejected'),
+                ] },
+              ],
+            },
+          }
+          const markdown = `${title}\n${content}\n\n点击按钮完成裁决${isUserTarget ? '（仅你本人可点）' : ''}：`
+          const messageId = await postMarkdownWithKeyboard(chatId, markdown, keyboard)
+          if (messageId !== null) return { messageId }
+        } catch (error) {
+          warn(`按钮卡片发送失败，本次降级文本审批: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
       try {
+        const text = `${title}\n${content}\n\n回复 1 批准 / 2 拒绝`
         const messageId = await postMessage(chatId, text)
         return messageId !== null ? { messageId } : null
       } catch (error) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -40,7 +40,9 @@ import { createScanHandlers } from './admin/scan.mjs'
 import { runChannelTest } from './health.mjs'
 
 export const name = 'dsh-notifier'
-export const inject = ['tools', 'agents']
+// 2026-08-25 修：提问桥桌面腿访问 ctx.userQuestions（宿主服务，apiproxy 注册 provider），
+// cordis rc.6 要求插件静态声明后方可访问——缺声明即抛 cannot get property without inject。
+export const inject = ['tools', 'agents', 'userQuestions']
 
 /** 返回已解析配置（供测试与其它插件复用）。 */
 export function apply(ctx, config = {}) {
@@ -736,11 +738,12 @@ export function apply(ctx, config = {}) {
         const disposeAskTool = registerAskUserTool(ctx, questionsBridge, {
           rateLimitPerMinute: resolved.questions.rateLimitPerMinute,
           defaultTimeoutMs: resolved.questions.timeoutMs,
+          parallel: resolved.questions.parallel,
         })
         if (disposeAskTool !== null) disposers.push(disposeAskTool)
         questionsBridge.attach()
         disposers.push(() => questionsBridge.dispose())
-        warn(`远程提问已启用：ask_user 工具（限流 ${resolved.questions.rateLimitPerMinute} 次/分钟，超时 ${Math.round(resolved.questions.timeoutMs / 1000)}s 不代答）；飞书/Telegram 单选选项卡 + 全渠道编号兜底`)
+        warn(`远程提问已启用：ask_user 工具（限流 ${resolved.questions.rateLimitPerMinute} 次/分钟，超时 ${Math.round(resolved.questions.timeoutMs / 1000)}s 不代答）${resolved.questions.parallel ? '；双端并行——桌面弹窗与手机卡片同出、先答先算' : ''}；飞书/Telegram 单选选项卡 + 全渠道编号兜底`)
       } catch (error) {
         warn(`questions 桥装配失败，已跳过（其余能力不受影响）: ${error instanceof Error ? error.message : String(error)}`)
       }

--- a/src/questions/router.mjs
+++ b/src/questions/router.mjs
@@ -218,7 +218,13 @@ export function createQuestionBridge(deps) {
     // 编号文案只发卡片未送达的渠道（P4 文字路径兜底）：卡片已到手的用户不再收
     // 一条冗余的「回复编号」广播——选项卡是主交互，编号是无卡片/投递失败时的降级。
     const allTypes = Array.isArray(notifier?.channels) ? notifier.channels : []
-    const textTypes = allTypes.filter((type) => !deliveredTypes.has(type))
+    // 出站名经别名映射折算成入站名再比对送达集（qq-bot↔qq 同款异名问题：
+    // 卡片已送达 qq 入站时，出站 qq-bot 不应重复发编号话术）。无别名映射的
+    // 渠道折算到自身名（telegram 等出入站同名，天然命中）。
+    const textTypes = allTypes.filter((type) => {
+      const inboundName = OUTBOUND_TO_INBOUND_ALIAS[String(type)] ?? String(type)
+      return !deliveredTypes.has(inboundName)
+    })
     if (textTypes.length > 0) {
       await notifier.notifyAll({
         title,
@@ -321,14 +327,91 @@ export function createQuestionBridge(deps) {
   }
 
   /**
+   * 提问按钮回调（v0.8.x qq INTERACTION）：envelope.questionAction 由 qq-gw 从
+   * aq:<qKey>:<optIdx|s|c>:<token> 解析注入。数字下标=单选提交（多选组合走编号
+   * 文本「1,3」）；'s'=跳过本问题（立即交还桌面，answered=false，绝不代答）；
+   * 'c'=自定义回答教学回执。安全链路与飞书卡片回调同路径：decide() 做 vault
+   * 验签 + pushedTo 来源（channel+chatId）校验 + 首达采纳。
+   */
+  function handleCardAction(envelope) {
+    const action = envelope?.questionAction
+    if (action === undefined || action === null) return false
+    const qKey = String(action.qKey ?? '')
+    const optIdx = String(action.optIdx ?? '')
+    const sendFeedback = (message) => {
+      const inbound = interactiveEntries().find((entry) => entry.channel === envelope.channel)
+      if (inbound !== undefined) void inbound.sendText(envelope.chatId, message)
+    }
+    if (/^(s|skip)$/i.test(optIdx)) {
+      const row = ledger.get(qKey)
+      if (row === undefined || row.status !== 'pending') {
+        sendFeedback('该提问已回答或已过期')
+        return true
+      }
+      const verdict = bus.settle(qKey, { kind: 'aq-skip', idxs: [] }, `${envelope.channel}:button`, envelope.userId)
+      if (!verdict.ok) {
+        sendFeedback('该提问已被作答（首达采纳）')
+        return true
+      }
+      ledger.resolve(qKey, 'skipped', { via: `${envelope.channel}:button`, userId: String(envelope.userId) })
+      warn(`${qKey} 已跳过（via ${envelope.channel}:button）`)
+      sendFeedback('⏭ 已跳过该提问：交还桌面处理')
+      return true
+    }
+    if (/^(c|custom)$/i.test(optIdx)) {
+      sendFeedback('✍️ 自定义回答：直接回复「答：<你的回答>」，该消息将作为本题答案提交（不进对话路由）')
+      return true
+    }
+    if (!/^\d$/.test(optIdx)) {
+      sendFeedback('无效的选项按钮')
+      return true
+    }
+    const verdict = decide({
+      qKey,
+      optIdx,
+      token: String(action.token ?? ''),
+      via: `${envelope.channel}:button`,
+      userId: envelope.userId,
+      chatId: envelope.chatId,
+    })
+    if (verdict.ok === true) sendFeedback(`✅ 已作答：${(verdict.answers ?? []).join('、')}`)
+    else sendFeedback(verdict.message ?? '作答失败')
+    return true
+  }
+
+  /**
    * 编号回复兜底（P4）：白名单用户回复 '2' / '1,3'（中英文逗号均可）作答最近一条待决提问。
    * 发错了不作废——无效编号：消费该消息（不进对话路由）+ 回执提示 + 把选项重发一遍，
    * 问题保持待决，用户直接再答即可；有效作答后回执确认。
    * 消费语义与审批一致：返回 true = bus 停止扇出（不进对话路由）。
    * 注意：审批的编号处理器先注册（'1'/'2' 且有待决审批时审批优先消费）。
+   * v0.8.x 自定义回答：「答：内容」前缀 + 该渠道用户有待决提问 → 文本作为答案提交。
+   * 必须带前缀：裸文本永远进对话路由，绝不劫持普通聊天。
    */
   function handleNumberedReply(envelope) {
     const text = String(envelope.text ?? '').trim()
+    if (/^答[:：]/.test(text)) {
+      const pending = ledger.latestPendingFor(envelope.channel, envelope.userId)
+      if (pending === null) return false // 无待决提问：放行进对话路由
+      const answer = text.replace(/^答[:：]\s*/, '').trim()
+      const sendAnswerFeedback = (message) => {
+        const inbound = interactiveEntries().find((entry) => entry.channel === envelope.channel)
+        if (inbound !== undefined) void inbound.sendText(envelope.chatId, message)
+      }
+      if (answer === '') {
+        sendAnswerFeedback('✍️ 请在「答：」后面写上你的回答，例如：答：用方案 B')
+        return true
+      }
+      const verdict = bus.settle(pending.key, { kind: 'aq-text', idxs: [], text: answer }, `${envelope.channel}:text`, envelope.userId)
+      if (!verdict.ok) {
+        sendAnswerFeedback('该提问已被作答（首达采纳）')
+        return true
+      }
+      ledger.resolve(pending.key, 'answered', { answers: [answer], via: `${envelope.channel}:text`, userId: String(envelope.userId) })
+      warn(`${pending.key} 自定义作答：${answer.slice(0, 40)}（via ${envelope.channel}:text）`)
+      sendAnswerFeedback(`✅ 已作答（自定义）：${answer}`)
+      return true
+    }
     if (!/^\d{1,2}([,，]\d{1,2})*$/.test(text)) return false
     const nums = text.split(/[,，]/).map(Number)
     if (nums.length === 0) return false
@@ -365,16 +448,19 @@ export function createQuestionBridge(deps) {
     return true
   }
 
+  let disposeCardAction = null
   let disposeMessage = null
   let disposed = false
 
   /**
-   * 挂载编号回复处理器。必须在审批路由注册之后调用（bus.onMessage 插入序 =
-   * 消费优先级：审批 '1'/'2' 先于提问编号，避免歧义时提问抢走审批回复）。
+   * 挂载按钮回调 + 编号回复处理器。必须在审批路由注册之后调用（bus.onMessage 插入序 =
+   * 消费优先级：审批 '1'/'2' 先于提问编号，避免歧义时提问抢走审批回复）。按钮回调与
+   * 编号互不相干（questionAction 信封 vs 纯数字文本），先后无谓，同批挂载。
    */
   function attach() {
-    if (disposeMessage !== null || disposed) return
-    disposeMessage = bus.onMessage(handleNumberedReply)
+    if (disposed) return
+    if (disposeCardAction === null) disposeCardAction = bus.onMessage(handleCardAction)
+    if (disposeMessage === null) disposeMessage = bus.onMessage(handleNumberedReply)
   }
 
   /**
@@ -437,6 +523,20 @@ export function createQuestionBridge(deps) {
           allAnswered = false
           continue
         }
+        // 提问按钮「跳过」（v0.8.x）：绝不代答，立即交还桌面（与超时同语义、更快）
+        if (outcome?.decision?.kind === 'aq-skip') {
+          await markResolved(ledger.get(qKey)?.pushedTo ?? [], '⏭ 已跳过：交还桌面处理')
+          results.push({ question: String(question.question ?? ''), answered: false, reason: 'skipped-by-user' })
+          allAnswered = false
+          continue
+        }
+        // 自定义文本作答（「答：内容」前缀）：答案即用户输入的自由文本
+        if (outcome?.decision?.kind === 'aq-text') {
+          const customAnswer = String(outcome.decision.text ?? '')
+          await markResolved(ledger.get(qKey)?.pushedTo ?? [], `✅ 已作答（自定义）：${customAnswer}`)
+          results.push({ question: String(question.question ?? ''), answered: true, answers: [customAnswer], via: outcome.via })
+          continue
+        }
       } catch (error) {
         warn(`提问推送/等待异常（交还桌面语义）: ${error instanceof Error ? error.message : String(error)}`)
         try { escalation.stop(qKey) } catch { /* 清理不致命 */ }
@@ -469,7 +569,9 @@ export function createQuestionBridge(deps) {
 
   function dispose() {
     disposed = true
+    try { disposeCardAction?.() } catch { /* 反注册失败不致命 */ }
     try { disposeMessage?.() } catch { /* 反注册失败不致命 */ }
+    disposeCardAction = null
     disposeMessage = null
     escalation.dispose()
   }

--- a/src/questions/router.mjs
+++ b/src/questions/router.mjs
@@ -95,6 +95,10 @@ export function createQuestionBridge(deps) {
     logger,
   })
 
+  // 武装模式登记表：点「✍️ 自定义」后 (channel:userId) → qKey，该用户下一条消息
+  // 即作为对应提问的答案。进程内存态（不落库）——重启即清空，安全侧倾斜。
+  const armedCustom = new Map()
+
   const ledger = {
     add(key, row) {
       store.set(key, { ...row, status: 'pending', createdAt: Date.now() })
@@ -355,11 +359,17 @@ export function createQuestionBridge(deps) {
       }
       ledger.resolve(qKey, 'skipped', { via: `${envelope.channel}:button`, userId: String(envelope.userId) })
       warn(`${qKey} 已跳过（via ${envelope.channel}:button）`)
-      sendFeedback('⏭ 已跳过该提问：交还桌面处理')
+      // 成功路径不在此回执：askQuestions 收尾的 markResolved 会广播唯一一条
+      // 「⏭ 已跳过：交还桌面处理」，这里再发就是同事件双播报（2026-08-24 实测）。
       return true
     }
     if (/^(c|custom)$/i.test(optIdx)) {
-      sendFeedback('✍️ 自定义回答：直接回复「答：<你的回答>」，该消息将作为本题答案提交（不进对话路由）')
+      // 武装模式：点「✍️ 自定义」= 该用户在此渠道的下一条消息直接成为本题答案
+      // （2026-08-24 实测反馈：要求先打「答：」前缀反直觉——用户点了按钮就期望
+      // 立刻能说话）。武装只对 (channel+userId) 生效、随问题终态自动失效；
+      // 免按钮场景仍可用「答：内容」前缀直达。
+      armedCustom.set(`${envelope.channel}:${envelope.userId}`, qKey)
+      sendFeedback('✍️ 请直接输入你的回答：下一条消息将作为本题答案提交')
       return true
     }
     if (!/^\d$/.test(optIdx)) {
@@ -374,8 +384,9 @@ export function createQuestionBridge(deps) {
       userId: envelope.userId,
       chatId: envelope.chatId,
     })
-    if (verdict.ok === true) sendFeedback(`✅ 已作答：${(verdict.answers ?? []).join('、')}`)
-    else sendFeedback(verdict.message ?? '作答失败')
+    // 成功路径不在此回执：askQuestions 收尾的 markResolved 会广播唯一一条
+    // 「[审批结果] ✅ 已作答：…（来源 qq:button）」（同事件双播报修复）。
+    if (verdict.ok !== true) sendFeedback(verdict.message ?? '作答失败')
     return true
   }
 
@@ -390,6 +401,31 @@ export function createQuestionBridge(deps) {
    */
   function handleNumberedReply(envelope) {
     const text = String(envelope.text ?? '').trim()
+    // 武装模式消费（优先于一切文本规则）：点过「✍️ 自定义」的用户，下一条消息
+    // 无论内容（含纯数字如「111」）都作为本题答案提交。问题已终态则自动解除武装
+    // 并放行消息。成功不即时回执（markResolved 收尾播报唯一化）。
+    const armedKey = `${envelope.channel}:${envelope.userId}`
+    if (armedCustom.has(armedKey)) {
+      const qKey = armedCustom.get(armedKey)
+      const row = ledger.get(qKey)
+      const disarm = () => armedCustom.delete(armedKey)
+      if (row === undefined || row.status !== 'pending') {
+        disarm()
+        return false // 问题已终态：解除武装，消息照常走后续处理
+      }
+      const answer = text.replace(/^答[:：]\s*/, '').trim()
+      disarm() // 一次性消费：无论成败都不再拦截下一条
+      if (answer === '') return true // 空消息只解除武装，静默吞掉
+      const verdict = bus.settle(qKey, { kind: 'aq-text', idxs: [], text: answer }, `${envelope.channel}:text`, envelope.userId)
+      if (!verdict.ok) {
+        const inbound = interactiveEntries().find((entry) => entry.channel === envelope.channel)
+        if (inbound !== undefined) void inbound.sendText(envelope.chatId, '该提问已被作答（首达采纳）')
+        return true
+      }
+      ledger.resolve(qKey, 'answered', { answers: [answer], via: `${envelope.channel}:text`, userId: String(envelope.userId) })
+      warn(`${qKey} 自定义作答：${answer.slice(0, 40)}（via ${envelope.channel}:text）`)
+      return true
+    }
     if (/^答[:：]/.test(text)) {
       const pending = ledger.latestPendingFor(envelope.channel, envelope.userId)
       if (pending === null) return false // 无待决提问：放行进对话路由
@@ -409,7 +445,7 @@ export function createQuestionBridge(deps) {
       }
       ledger.resolve(pending.key, 'answered', { answers: [answer], via: `${envelope.channel}:text`, userId: String(envelope.userId) })
       warn(`${pending.key} 自定义作答：${answer.slice(0, 40)}（via ${envelope.channel}:text）`)
-      sendAnswerFeedback(`✅ 已作答（自定义）：${answer}`)
+      // 成功路径不在此回执：markResolved 收尾播报唯一化（同双播报修复）
       return true
     }
     if (!/^\d{1,2}([,，]\d{1,2})*$/.test(text)) return false

--- a/src/questions/router.mjs
+++ b/src/questions/router.mjs
@@ -99,6 +99,12 @@ export function createQuestionBridge(deps) {
   // 即作为对应提问的答案。进程内存态（不落库）——重启即清空，安全侧倾斜。
   const armedCustom = new Map()
 
+  // 双端并行（2026-08-24）：当前批次仍待决的 qKey 集合 + 「桌面已抢先提交」旗标。
+  // 桌面（ctx.userQuestions 弹窗）先答 → 工具层调 abortActiveByDesktop() 终结远端
+  // 待决卡；askQuestions 循环头见旗标即不再发后续问题（桌面一次答完整批）。
+  let activeWaitKeys = new Set()
+  let desktopWonFirst = false
+
   const ledger = {
     add(key, row) {
       store.set(key, { ...row, status: 'pending', createdAt: Date.now() })
@@ -518,7 +524,14 @@ export function createQuestionBridge(deps) {
         allAnswered = false
         continue
       }
+      // 双端并行：桌面已抢先提交整批答案——后续问题不再外发，直接记「已在别处作答」
+      if (desktopWonFirst) {
+        results.push({ question: String(question?.question ?? ''), answered: false, reason: 'answered-elsewhere' })
+        allAnswered = false
+        continue
+      }
       const qKey = `${KEY_PREFIX}${randomBytes(4).toString('hex')}`
+      activeWaitKeys.add(qKey)
       let outcome = null
       try {
         const token = vault.mint(qKey)
@@ -563,6 +576,14 @@ export function createQuestionBridge(deps) {
         if (outcome?.decision?.kind === 'aq-skip') {
           await markResolved(ledger.get(qKey)?.pushedTo ?? [], '⏭ 已跳过：交还桌面处理')
           results.push({ question: String(question.question ?? ''), answered: false, reason: 'skipped-by-user' })
+          allAnswered = false
+          continue
+        }
+        // 双端并行：桌面/Web 抢先作答，本卡终结（工具层改用桌面答案组装结果）
+        if (outcome?.decision?.kind === 'aq-abort') {
+          ledger.resolve(qKey, 'answered-elsewhere', { via: 'web', userId: '(desktop)' })
+          await markResolved(ledger.get(qKey)?.pushedTo ?? [], '🖥️ 已在桌面/Web 作答，此卡已失效')
+          results.push({ question: String(question.question ?? ''), answered: false, reason: 'answered-elsewhere' })
           allAnswered = false
           continue
         }
@@ -612,7 +633,23 @@ export function createQuestionBridge(deps) {
     escalation.dispose()
   }
 
-  return { askQuestions, decide, decideTrusted, attach, dispose }
+  /** 双端并行：桌面/Web 已提交作答——终结本批次所有仍待决的远端提问（waiter 唤醒、
+   *  卡片终态化由 aq-abort 分支收尾）。旗标置位后 askQuestions 不再外发后续问题。 */
+  function abortActiveByDesktop() {
+    if (disposed) return
+    desktopWonFirst = true
+    const keys = [...activeWaitKeys]
+    activeWaitKeys = new Set()
+    for (const key of keys) {
+      try {
+        const row = ledger.get(key)
+        if (row === undefined || row.status !== 'pending') continue
+        bus.settle(key, { kind: 'aq-abort', idxs: [] }, 'web', '(desktop)')
+      } catch { /* 单键终结失败不拖垮其余 */ }
+    }
+  }
+
+  return { askQuestions, decide, decideTrusted, attach, dispose, abortActiveByDesktop }
 }
 
 /** 校验并归一 ask_user 工具参数；违规返回 { ok:false, reason }。 */
@@ -650,11 +687,33 @@ export function validateAskArgs(rawArgs, { minTimeoutMs = 30_000, maxTimeoutMs =
   return { ok: true, questions, timeoutMs, context }
 }
 
+/** 把宿主原生应答 {answers:[{id,selected[],custom?}]} 映射为插件结果形状。
+ *  custom 优先（桌面自由输入），其次 selected 标签；两者皆空 = 桌面上跳过。 */
+function mapDesktopAnswer(answer, questions) {
+  const rows = Array.isArray(answer?.answers) ? answer.answers : []
+  const results = []
+  let allAnswered = true
+  questions.forEach((question, index) => {
+    const item = rows.find((row) => row?.id === `q${index + 1}`) ?? rows[index] ?? null
+    const custom = typeof item?.custom === 'string' ? item.custom.trim() : ''
+    const labels = Array.isArray(item?.selected) ? item.selected.filter((label) => label !== '') : []
+    if (custom !== '') {
+      results.push({ question: question.question, answered: true, answers: [custom], via: 'web' })
+    } else if (labels.length > 0) {
+      results.push({ question: question.question, answered: true, answers: labels, via: 'web' })
+    } else {
+      results.push({ question: question.question, answered: false, reason: 'skipped-on-desktop' })
+      allAnswered = false
+    }
+  })
+  return { ok: true, answered: allAnswered, results, via: 'web', dualEnd: true }
+}
+
 /**
  * 注册 ask_user 工具（v0.8 远程提问）。
  * @param ctx - cordis 上下文（ctx.tools；宿主没有 tools 服务时静默跳过）
  * @param {ReturnType<typeof createQuestionBridge>} bridge
- * @param {{ rateLimitPerMinute?: number, defaultTimeoutMs?: number }} [options]
+ * @param {{ rateLimitPerMinute?: number, defaultTimeoutMs?: number, parallel?: boolean }} [options]
  */
 export function registerAskUserTool(ctx, bridge, options = {}) {
   if (ctx?.tools?.register === undefined) {
@@ -664,14 +723,14 @@ export function registerAskUserTool(ctx, bridge, options = {}) {
   const limiter = createRateLimiter({ limitPerMinute: options.rateLimitPerMinute ?? 6 })
   return ctx.tools.register({
     name: 'ask_user',
-    description: '向用户提出选择题并等待作答（推送到用户手机：飞书选项卡片 / Telegram 按钮 / 其他渠道回复编号）。适合方案抉择、环境选择等需要用户拍板的分叉决策；用户装了 dsh-notifier 手机桥接时优先用本工具而不是 ask_user_question。超时不会代答——用户未作答时返回 answered=false，请改用桌面确认或调整方案继续。',
+    description: '向用户提出选择题并等待作答。双端并行：桌面 Web 弹窗与手机卡片同时出现，先答先算（与审批并行裁决同构）；远端超时未答而弹窗仍开时继续等桌面。适合方案抉择、环境选择等需要用户拍板的分叉决策；用户装了 dsh-notifier 手机桥接时优先用本工具而不是 ask_user_question。超时不会代答。',
     parameters: compileParameters({
       questions: {
         type: 'array',
         required: true,
         description: '1-4 个问题，每项 { question: 问题正文, options: [{ label: 选项 }](2-5 项), multiSelect?: 是否多选（默认 false） }',
       },
-      timeoutMs: { type: 'number', description: '作答时限毫秒（默认 300000，范围 30s-30min）；超时不代答' },
+      timeoutMs: { type: 'number', description: '作答时限毫秒（默认 300000，范围 30s-30min）；远端超时不代答，桌面弹窗仍开则继续等待' },
       context: { type: 'string', description: '为什么问（卡片引言，可选，300 字内）' },
     }),
     output: {
@@ -709,10 +768,70 @@ export function registerAskUserTool(ctx, bridge, options = {}) {
       if (!validated.ok) {
         return { ok: false, answered: false, results: [], reason: validated.reason }
       }
+      // —— 双端并行（与审批 parallel 同构）：工具执行即同时弹桌面 Web 弹窗 + 推远端
+      // 卡片，先答先算。宿主没有 userQuestions 服务或 parallel 关闭时回落单端瀑布。
+      // 时序语义：
+      //   桌面先提交 → 终结远端待决卡，整批改用桌面答案；
+      //   远端全答完 → abort 弹窗，用远端结果；
+      //   远端超时/跳过而桌面仍开 → 继续等桌面（「远程窗口先关，继续等桌面」）；
+      //   桌面被用户关掉/服务不可用 → 回落远端结论，行为与单端一致。
+      // 2026-08-25 修：cordis 对插件内未声明注入的服务属性访问直接抛错（rc.6 拦截），
+      // 可选链救不了属性读取本身。已在插件级 inject 声明 userQuestions；此处再兜一层
+      // try/catch——服务缺失/作用域异常时回落单端瀑布，绝不弄崩工具。
+      let nativeAsk = null
       try {
-        return await bridge.askQuestions(validated, execContext)
+        nativeAsk = ctx?.userQuestions?.ask ?? null
+      } catch {
+        nativeAsk = null
+      }
+      if (options.parallel !== true || typeof nativeAsk !== 'function') {
+        try {
+          return await bridge.askQuestions(validated, execContext)
+        } catch (error) {
+          return { ok: false, answered: false, results: [], reason: error instanceof Error ? error.message : String(error) }
+        }
+      }
+      const desktopQuestions = validated.questions.map((question, index) => ({
+        id: `q${index + 1}`, // 原生契约要求稳定 id，应答按 id 回显
+        question: String(question.question ?? ''),
+        ...(Array.isArray(question.options) ? { options: question.options } : {}),
+        multiSelect: question.multiSelect === true,
+      }))
+      const controller = new AbortController()
+      let desktopWin = null // 桌面先提交时回填 { answer }
+      const desktopSettled = Promise.resolve().then(() => nativeAsk.call(ctx.userQuestions, {
+        questions: desktopQuestions,
+        ...(execContext?.agent !== undefined ? { agent: execContext.agent } : {}),
+        signal: controller.signal,
+      })).then(
+        (answer) => {
+          desktopWin = { answer }
+          try { bridge.abortActiveByDesktop() } catch { /* 单键终结失败不影响取答 */ }
+          return 'won'
+        },
+        () => 'lost', // 用户关掉弹窗 / 无 agent 会话 / 服务校验拒绝：远端线照旧
+      )
+      desktopSettled.catch(() => {}) // 竞速败方的结果已被消费，防未处理拒绝
+      try {
+        const remoteOutcome = await bridge.askQuestions(validated, execContext)
+        if (desktopWin !== null) {
+          return mapDesktopAnswer(desktopWin.answer, validated.questions)
+        }
+        if (remoteOutcome.answered === true) {
+          controller.abort() // 远端全答完：撤掉还没人理的桌面弹窗
+          // 收尸等待加宽限界：正常提供方（apiproxy）abort 即拒绝，此处只等它落定；
+          // 异常提供方永不落定也不能拖住工具返回（结果已定）。
+          await Promise.race([desktopSettled, new Promise((resolve) => setTimeout(resolve, 2000))])
+          return remoteOutcome
+        }
+        // 远端没答全（超时/跳过/终止）：远程窗口先关，继续等桌面兜底
+        if (await desktopSettled === 'won') {
+          return mapDesktopAnswer(desktopWin.answer, validated.questions)
+        }
+        return remoteOutcome
       } catch (error) {
-        return { ok: false, answered: false, results: [], reason: error instanceof Error ? error.message : String(error) }
+        controller.abort()
+        throw error
       }
     },
   })

--- a/test/approval.parallel.test.mjs
+++ b/test/approval.parallel.test.mjs
@@ -1,0 +1,119 @@
+// approval.parallel 测试：并行竞速语义 + 缺省排他回归。
+// 断言安全红线不破：静默永不批准、单次返回、首达采纳、异常退回桌面。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { registerApprovalHandler } from '../src/approval/router.mjs'
+import { createInboundBus } from '../src/inbound/bus.mjs'
+import { createTokenVault } from '../src/inbound/tokens.mjs'
+import { createStore } from '../src/inbound/store.mjs'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * 最小依赖装配：真实 bus/vault/store + 假 ctx/notifier/telegram。
+ * deferredDesktop=true 时 next() 返回挂起的 promise，由 releaseDesktop() 手动放行，
+ * 用于模拟"桌面询问在途/迟到"的竞速场景。
+ */
+function makeRig({ approvalConfig = {}, deferredDesktop = false } = {}) {
+  const store = createStore(join(mkdtempSync(join(tmpdir(), 'dsh-notifier-par-')), 'state.json'))
+  const vault = createTokenVault({ secret: 'par-secret' })
+  const bus = createInboundBus({ allowUsers: ['42'], store, vault })
+  const handlers = {}
+  const ctx = {
+    on: (event, handler) => { handlers[event] = handler; return () => { delete handlers[event] } },
+  }
+  const broadcasts = []
+  const notifier = {
+    notifyAll: async (msg) => { broadcasts.push(msg); return { ok: true, delivered: [], skipped: [], failed: [] } },
+  }
+  const cards = []
+  const edits = []
+  const telegram = {
+    notifyChatIds: () => ['100'],
+    sendApprovalCard: async ({ chatId, title, approvalKey, token }) => {
+      const card = { chatId, title, approvalKey, token, messageId: cards.length + 1 }
+      cards.push(card)
+      return { messageId: card.messageId }
+    },
+    editResolved: async (chatId, messageId, text) => { edits.push({ chatId, messageId, text }) },
+  }
+  registerApprovalHandler({
+    ctx, notifier, bus, vault, store, telegram,
+    counterStart: 0,
+    approvalConfig: { mode: 'answer', ...approvalConfig },
+  })
+  let releaseDesktop = () => {}
+  let desktopValue = 'desktop-deferred'
+  const desktopGate = new Promise((resolve) => {
+    releaseDesktop = (value) => { if (value !== undefined) desktopValue = value; resolve() }
+  })
+  const nextCalls = []
+  const handle = (request) => handlers['approval/request'](request, () => {
+    nextCalls.push(Date.now())
+    if (!deferredDesktop) return 'desktop-immediate'
+    return desktopGate.then(() => desktopValue)
+  })
+  return { store, bus, broadcasts, cards, edits, handle, releaseDesktop, nextCalls }
+}
+
+test('parallel：next 立即放行；远程先决返回 allowed-once', async () => {
+  const rig = makeRig({ approvalConfig: { parallel: true, timeoutMs: 5000 }, deferredDesktop: true })
+  const pending = rig.handle({ toolName: 'rm', callId: 'p1', reason: '删除文件' })
+  await sleep(10) // 让推卡与 next() 放行完成
+  assert.equal(rig.nextCalls.length, 1) // 桌面询问已立即发出（排他模式此时为 0）
+  rig.bus.decideTrusted({ approvalKey: 'ap:p1:1', decision: 'allowed-once', via: 'qq:reply', userId: '42' })
+  assert.equal(await pending, 'allowed-once')
+  assert.equal(rig.store.get('ap:p1:1').decision, 'allowed-once')
+})
+
+test('parallel：桌面先行——结果透传、远程 waiter 撤销、卡片改写', async () => {
+  const rig = makeRig({ approvalConfig: { parallel: true, timeoutMs: 3000 }, deferredDesktop: true })
+  const pending = rig.handle({ toolName: 'rm', callId: 'p2' })
+  await sleep(20)
+  rig.releaseDesktop('desktop-said-ok')
+  assert.equal(await pending, 'desktop-said-ok') // 下游返回值原样透传
+  const verdict = rig.bus.decideTrusted({ approvalKey: 'ap:p2:1', decision: 'allowed-once', via: 'qq:reply', userId: '42' })
+  assert.equal(verdict.ok, false) // 迟到的远程裁决被拒收
+  assert.equal(verdict.reason, 'already-resolved')
+  assert.equal(rig.store.get('ap:p2:1').status, 'resolved') // 账本不悬挂 pending
+  assert.ok(rig.edits.some((e) => /已在桌面处理/.test(e.text)))
+})
+
+test('parallel：远程先决后，迟到的桌面结果不影响账本与返回值', async () => {
+  const rig = makeRig({ approvalConfig: { parallel: true, timeoutMs: 3000 }, deferredDesktop: true })
+  const pending = rig.handle({ toolName: 'rm', callId: 'p3' })
+  await sleep(20)
+  rig.bus.decideTrusted({ approvalKey: 'ap:p3:1', decision: 'rejected', via: 'qq:reply', userId: '42' })
+  assert.equal(await pending, 'rejected')
+  rig.releaseDesktop() // 迟到的桌面结果——不得抛未处理拒绝、不得改账本
+  await sleep(10)
+  assert.equal(rig.store.get('ap:p3:1').decision, 'rejected')
+  assert.ok(rig.edits.some((e) => /已远程拒绝/.test(e.text)))
+})
+
+test('parallel：远程窗口先超时——卡片改交还文案，最终以桌面结果收束', async () => {
+  // 注意 router 将 timeoutMs 钳制到下限 1000ms：用例用 1000ms 并等 1150ms 再断言
+  const rig = makeRig({ approvalConfig: { parallel: true, timeoutMs: 1000 }, deferredDesktop: true })
+  const pending = rig.handle({ toolName: 'rm', callId: 'p4' })
+  await sleep(1150)
+  assert.ok(rig.edits.some((e) => /手机端等待超时/.test(e.text)))
+  rig.releaseDesktop('desktop-late')
+  assert.equal(await pending, 'desktop-late')
+  assert.ok(rig.edits.some((e) => /已在桌面处理/.test(e.text)))
+})
+
+test('parallel 缺省：保持上游排他语义——等待期内不调用 next', async () => {
+  const rig = makeRig({ approvalConfig: { timeoutMs: 80 }, deferredDesktop: true })
+  const t0 = Date.now()
+  const pending = rig.handle({ toolName: 'rm', callId: 'p5' })
+  await sleep(30)
+  assert.equal(rig.nextCalls.length, 0) // 排他模式：等待期内桌面不被询问
+  rig.releaseDesktop() // 超时交还后 next() 会等待桌面结果——放行闸门
+  const result = await pending
+  assert.ok(Date.now() - t0 >= 70)
+  assert.equal(result, 'desktop-deferred')
+  assert.ok(rig.edits.some((e) => /超时未响应/.test(e.text)))
+})

--- a/test/button-interaction.test.mjs
+++ b/test/button-interaction.test.mjs
@@ -1,0 +1,154 @@
+// button-interaction 测试：QQ 官方 bot 按钮化审批的端到端语义。
+// 覆盖：契约负载 roundtrip、INTERACTION 回调显式 key 裁决、接收人校验、
+// 已决竞态回执、伪造 token 拒绝、文本形态兜底（指令按钮/旧客户端）、
+// 广播去重（卡片成功后出站孪生静默）与广播兜底（卡片失败时照发）。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { registerApprovalHandler } from '../src/approval/router.mjs'
+import { createInboundBus } from '../src/inbound/bus.mjs'
+import { createTokenVault } from '../src/inbound/tokens.mjs'
+import { createStore } from '../src/inbound/store.mjs'
+import { buildApprovalAction, parseApprovalAction } from '../src/inbound/_contract.mjs'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const OPENID_A = 'A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4' // 审批接收人
+const OPENID_B = 'B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5' // 另一位绑定成员
+
+/** 最小装配：真实 bus/vault/store + 统一契约形状的 qq 假通道。 */
+function makeRig({ timeoutMs = 5000, failCard = false } = {}) {
+  const store = createStore(join(mkdtempSync(join(tmpdir(), 'dsh-notifier-btn-')), 'state.json'))
+  const vault = createTokenVault({ secret: 'btn-secret' })
+  const bus = createInboundBus({ allowUsers: [OPENID_A, OPENID_B], store, vault })
+  const handlers = {}
+  const ctx = { on: (event, handler) => { handlers[event] = handler; return () => { delete handlers[event] } } }
+  const broadcasts = []
+  const notifier = {
+    channels: ['qq-bot'], // 真实出站注册名（入站交互渠道名为 'qq'，经别名表桥接）
+    notifyAll: async (msg) => { broadcasts.push(msg); return { ok: true, delivered: [], skipped: [], failed: [] } },
+  }
+  const cards = []
+  const receipts = []
+  const edits = []
+  const qqLike = {
+    channel: 'qq',
+    capabilities: { buttons: true },
+    notifyTargets: () => [{ chatId: OPENID_A, userId: OPENID_A }],
+    sendApprovalCard: async ({ chatId, title, content, approvalKey, token }) => {
+      if (failCard) return null
+      cards.push({ chatId, title, content, approvalKey, token })
+      return { messageId: `msg-${cards.length}` }
+    },
+    editResolved: async (target, text) => { edits.push({ target, text }) },
+    sendText: async (chatId, text) => { receipts.push({ chatId, text }); return true },
+  }
+  registerApprovalHandler({
+    ctx, notifier, bus, vault, store, interactive: [qqLike],
+    counterStart: 0,
+    approvalConfig: { mode: 'answer', timeoutMs },
+  })
+  const handle = (request) => handlers['approval/request'](request, () => 'desktop-immediate')
+  /** 模拟 qq-gw 的 INTERACTION_CREATE → bus.accept 注入路径。 */
+  const click = (messageId, clickerOpenid, decision, approvalKey, token) => {
+    const payload = buildApprovalAction(decision, approvalKey, token)
+    const parsed = parseApprovalAction(payload)
+    assert.notEqual(parsed, null, '契约负载必须可解析')
+    return bus.accept({
+      channel: 'qq',
+      userId: clickerOpenid,
+      chatId: clickerOpenid,
+      messageId,
+      text: `[审批按钮:${parsed.decision}] ${parsed.approvalKey}`,
+      approvalAction: { decision: parsed.decision, approvalKey: parsed.approvalKey, token: parsed.token },
+    })
+  }
+  return { store, bus, vault, cards, receipts, edits, broadcasts, handle, click }
+}
+
+test('契约负载 roundtrip：key 含冒号时中间段完整重组，token 取末段', () => {
+  const key = 'ap:some-call-id:12345'
+  const parsed = parseApprovalAction(buildApprovalAction('allowed-once', key, 'tok-abc'))
+  assert.deepEqual(parsed, { decision: 'allowed-once', approvalKey: key, token: 'tok-abc' })
+  assert.equal(parseApprovalAction('garbage'), null)
+  assert.equal(parseApprovalAction('ap:only:three'), null) // 缺 token 段
+})
+
+test('按钮点击：显式 key 精确裁决 pending 审批 → allowed-once', async () => {
+  const rig = makeRig()
+  const pending = rig.handle({ toolName: 'pwsh', callId: 'bt1', reason: '按钮化测试' })
+  await sleep(20)
+  assert.equal(rig.cards.length, 1)
+  assert.equal(rig.cards[0].approvalKey, 'ap:bt1:1')
+  const result = rig.click('interaction-1', OPENID_A, 'allowed-once', rig.cards[0].approvalKey, rig.cards[0].token)
+  assert.equal(result.ok, true)
+  assert.equal(await pending, 'allowed-once')
+  assert.equal(rig.store.get('ap:bt1:1').decision, 'allowed-once')
+})
+
+test('非接收人点击：用户级校验拦截，行保持 pending，收到拒绝回执', async () => {
+  const rig = makeRig({ timeoutMs: 900 })
+  rig.handle({ toolName: 'pwsh', callId: 'bt2' })
+  await sleep(20)
+  rig.click('interaction-2', OPENID_B, 'rejected', rig.cards[0].approvalKey, rig.cards[0].token)
+  assert.equal(rig.store.get('ap:bt2:1').status, 'pending')
+  assert.ok(rig.receipts.some((r) => /仅审批接收人/.test(r.text)))
+})
+
+test('已决审批再点：回执「已被处理」，不翻账本（首达采纳）', async () => {
+  const rig = makeRig({ timeoutMs: 900 })
+  const pending = rig.handle({ toolName: 'rm', callId: 'bt3' })
+  await sleep(20)
+  rig.bus.decideTrusted({ approvalKey: 'ap:bt3:1', decision: 'rejected', via: 'test' })
+  assert.equal(await pending, 'rejected')
+  rig.click('interaction-3', OPENID_A, 'allowed-once', 'ap:bt3:1', rig.cards[0].token)
+  assert.ok(rig.receipts.some((r) => /已被处理或已失效/.test(r.text)))
+  assert.equal(rig.store.get('ap:bt3:1').decision, 'rejected') // 首达采纳不被推翻
+})
+
+test('伪造 token：bus.decide 验签拒绝，账本不动', async () => {
+  const rig = makeRig({ timeoutMs: 900 })
+  rig.handle({ toolName: 'edit', callId: 'bt4' })
+  await sleep(20)
+  rig.click('interaction-4', OPENID_A, 'allowed-once', 'ap:bt4:1', 'forged-token-value')
+  assert.equal(rig.store.get('ap:bt4:1').status, 'pending')
+  assert.ok(rig.receipts.some((r) => /已被处理或已失效/.test(r.text)))
+})
+
+test('文本形态按钮负载兜底：指令按钮发出的纯文本同样裁决成功', async () => {
+  const rig = makeRig()
+  const pending = rig.handle({ toolName: 'pwsh', callId: 'bt5' })
+  await sleep(20)
+  const payload = buildApprovalAction('allowed-once', rig.cards[0].approvalKey, rig.cards[0].token)
+  // 模拟指令按钮/旧客户端：payload 作为普通文本消息到达（无 approvalAction 字段）
+  const result = rig.bus.accept({
+    channel: 'qq', userId: OPENID_A, chatId: OPENID_A,
+    messageId: 'interaction-5',
+    text: payload,
+  })
+  assert.equal(result.ok, true)
+  assert.equal(await pending, 'allowed-once')
+  assert.equal(rig.store.get('ap:bt5:1').decision, 'allowed-once')
+})
+
+test('广播去重：卡片成功后不重发审批通知（qq 单渠道零冗余）', async () => {
+  const rig = makeRig()
+  const pending = rig.handle({ toolName: 'pwsh', callId: 'bc1' })
+  await sleep(20)
+  assert.equal(rig.cards.length, 1)      // 卡片已发
+  assert.equal(rig.broadcasts.length, 0) // 出站孪生不再重发纯文本
+  rig.click('interaction-bc1', OPENID_A, 'allowed-once', rig.cards[0].approvalKey, rig.cards[0].token)
+  assert.equal(await pending, 'allowed-once')
+})
+
+test('广播兜底：卡片发送失败时广播照发（回复 1/2 教学不丢）', async () => {
+  const rig = makeRig({ timeoutMs: 900, failCard: true })
+  const pending = rig.handle({ toolName: 'pwsh', callId: 'bc2' })
+  await sleep(20)
+  assert.equal(rig.cards.length, 0)
+  assert.equal(rig.broadcasts.length, 1) // 无卡 → 兜底广播必须到达
+  rig.bus.decideTrusted({ approvalKey: 'ap:bc2:1', decision: 'rejected', via: 'test' })
+  assert.equal(await pending, 'rejected')
+})

--- a/test/inbound.qq.test.mjs
+++ b/test/inbound.qq.test.mjs
@@ -9,6 +9,8 @@ import { createInboundBus } from '../src/inbound/bus.mjs'
 const API = 'https://api.sgroup.qq.com'
 const TOKEN_URL = 'https://bots.qq.com/app/getAppAccessToken'
 const INTENT_GROUP_AND_C2C = 1 << 25
+const INTENT_INTERACTION = 1 << 26 // 按钮化审批：INTERACTION_CREATE 回调（v0.8.4）
+const DEFAULT_INTENTS = INTENT_GROUP_AND_C2C | INTENT_INTERACTION
 
 // ---------------------------------------------------------------- fakes
 
@@ -136,18 +138,18 @@ test('resolveQqInboundConfig：缺凭证 ok=false 中文指引；归一化 notif
   assert.deepEqual(ok.config.notifyUsers, ['u1'])
   assert.deepEqual(ok.config.notifyGroups, ['g1'])
   assert.equal(ok.config.intents, 1)
-  assert.equal(resolveQqInboundConfig({ appId: 'a', appSecret: 's' }).config.intents, INTENT_GROUP_AND_C2C)
+  assert.equal(resolveQqInboundConfig({ appId: 'a', appSecret: 's' }).config.intents, DEFAULT_INTENTS)
 })
 
 // ---------------------------------------------------------------- 网关握手
 
-test('握手：HELLO 后发 IDENTIFY（QQBot token + intents 1<<25）；READY 记录 session', async () => {
+test('握手：HELLO 后发 IDENTIFY（QQBot token + 群私聊|按钮互动 intents）；READY 记录 session', async () => {
   const rig = makeRig()
   const ws = await driveReady(rig)
   const identify = ws.sent.find((frame) => frame.op === 2)
   assert.ok(identify, '应发送 IDENTIFY')
   assert.equal(identify.d.token, 'QQBot AT_TOKEN')
-  assert.equal(identify.d.intents, INTENT_GROUP_AND_C2C)
+  assert.equal(identify.d.intents, DEFAULT_INTENTS)
   assert.deepEqual(identify.d.shard, [0, 1])
   assert.ok(rig.lines.some((line) => line.includes('网关已就绪') && line.includes('sess_1')))
   await rig.inbound.stop()
@@ -279,7 +281,7 @@ test('白名单外/空文本：不入站不抛异常', async () => {
 
 // ---------------------------------------------------------------- 出站能力
 
-test('sendApprovalCard：文本审批通知（无按钮话术）+ msg_seq 递增，返回 messageId', async () => {
+test('sendApprovalCard：按钮卡片优先（msg_type=2 + keyboard 回调按钮）+ msg_seq 递增，返回 messageId', async () => {
   const rig = makeRig()
   await driveReady(rig)
   const card = await rig.inbound.sendApprovalCard({ chatId: 'u_open', title: '需要批准：rm', content: '删除文件', approvalKey: 'ap:rm:1', token: 'tk' })
@@ -287,10 +289,21 @@ test('sendApprovalCard：文本审批通知（无按钮话术）+ msg_seq 递增
   const call = rig.calls.find((entry) => entry.url === `${API}/v2/users/u_open/messages`)
   assert.ok(call, '应 POST 单聊消息接口')
   assert.equal(call.headers.authorization, 'QQBot AT_TOKEN')
-  assert.equal(call.body.msg_type, 0)
+  // v0.8.4 按钮化：markdown + keyboard 长形式，两颗 type=1 回调按钮携带契约负载
+  assert.equal(call.body.msg_type, 2)
   assert.equal(call.body.msg_seq, 1)
-  assert.match(call.body.content, /需要批准：rm/)
-  assert.match(call.body.content, /回复 1 批准 \/ 2 拒绝/)
+  assert.match(call.body.markdown.content, /需要批准：rm/)
+  assert.match(call.body.markdown.content, /点击按钮完成裁决/)
+  const buttons = call.body.keyboard.content.rows[0].buttons
+  assert.equal(buttons.length, 2)
+  assert.equal(buttons[0].render_data.label, '✅ 批准')
+  assert.equal(buttons[1].render_data.label, '❌ 拒绝')
+  for (const [index, decision] of ['allowed-once', 'rejected'].entries()) {
+    assert.equal(buttons[index].action.type, 1, '必须是回调按钮（type=2 是指令语义）')
+    assert.equal(buttons[index].action.click_limit, 1)
+    assert.match(buttons[index].action.data, new RegExp(`^ap:${decision}:ap:rm:1:`), '契约协议 ap:<decision>:<key>:<token>')
+    assert.deepEqual(buttons[index].action.permission.specify_user_ids, ['u_open'], '单聊锁定接收人')
+  }
   const again = await rig.inbound.sendApprovalCard({ chatId: 'u_open', title: 't', content: 'c', approvalKey: 'k', token: 't' })
   assert.ok(again !== null)
   assert.equal(rig.calls.at(-1).body.msg_seq, 2, '同目标 msg_seq 递增（服务端按 seq 去重）')
@@ -332,14 +345,14 @@ test('editResolved：补发审批结果文本（消息不可编辑）；无 chat
   await rig.inbound.stop()
 })
 
-test('notifyTargets：notifyUsers + notifyGroups 优先，缺省回落全局白名单；capabilities.buttons=false', async () => {
+test('notifyTargets：notifyUsers + notifyGroups 优先，缺省回落全局白名单；capabilities.buttons=true（v0.8.4 按钮化）', async () => {
   const rig = makeRig({ config: { notifyUsers: ['u1', 'u2'], notifyGroups: ['g1'] } })
   assert.deepEqual(rig.inbound.notifyTargets(), [
     { chatId: 'u1', userId: 'u1' },
     { chatId: 'u2', userId: 'u2' },
     { chatId: 'g1', userId: 'g1' },
   ])
-  assert.deepEqual(rig.inbound.capabilities, { buttons: false })
+  assert.deepEqual(rig.inbound.capabilities, { buttons: true })
   const fallback = makeRig({ config: { notifyUsers: [], notifyGroups: [], fallbackTargets: ['u_global'] } })
   assert.deepEqual(fallback.inbound.notifyTargets(), [{ chatId: 'u_global', userId: 'u_global' }])
   await rig.inbound.stop()

--- a/test/question-card.test.mjs
+++ b/test/question-card.test.mjs
@@ -82,7 +82,7 @@ test('卡片推送：sendQuestionCard 收到契约参数并落账 pushedTo；不
   assert.deepEqual(outcome.results[0].answers, ['方案 B'])
 })
 
-test('按钮作答：数字下标经验签+来源校验裁决，回执确认', async () => {
+test('按钮作答：数字下标经验签+来源校验裁决，无即时回执（收尾播报唯一化）', async () => {
   const rig = makeRig()
   const pending = rig.ask()
   await sleep(30)
@@ -91,7 +91,7 @@ test('按钮作答：数字下标经验签+来源校验裁决，回执确认', a
   assert.equal(outcome.answered, true)
   assert.deepEqual(outcome.results[0].answers, ['方案 A'])
   assert.equal(outcome.results[0].via, 'qq:button')
-  assert.ok(rig.texts.some((t) => /✅ 已作答：方案 A/.test(t.text)))
+  assert.ok(!rig.texts.some((t) => /✅ 已作答/.test(t.text))) // 防双播报
 })
 
 test('跳过按钮：立即交还桌面（answered=false, skipped-by-user），绝不代答', async () => {
@@ -103,22 +103,38 @@ test('跳过按钮：立即交还桌面（answered=false, skipped-by-user），�
   assert.equal(outcome.answered, false)
   assert.equal(outcome.results[0].reason, 'skipped-by-user')
   assert.equal(rig.store.get(rig.cards[0].qKey).decision, 'skipped')
-  assert.ok(rig.texts.some((t) => /⏭ 已跳过/.test(t.text)))
+  assert.ok(!rig.texts.some((t) => /⏭ 已跳过/.test(t.text))) // 无即时回执：收尾播报唯一化
 })
 
-test('自定义教学按钮：问题保持待决，回执教「答：」前缀', async () => {
+test('自定义武装模式：点「✍️ 自定义」后下一条消息直接成为答案（含纯数字）', async () => {
   const rig = makeRig()
   const pending = rig.ask()
   await sleep(30)
   rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: 'c', token: rig.cards[0].token })
   await sleep(10)
-  assert.ok(rig.texts.some((t) => /✍️ 自定义回答/.test(t.text)))
+  assert.ok(rig.texts.some((t) => /请直接输入你的回答/.test(t.text)))
   assert.equal(rig.store.get(rig.cards[0].qKey).status, 'pending') // 未被消费
-  // 教学之后按「答：」提交自由文本 → 成为答案
-  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-custom', text: '答：用方案 B，理由如下' })
+  // 复现实测场景：用户点了自定义后输入「111」→ 应作为自由文本答案被捕获
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-arm1', text: '111' })
   const outcome = await pending
   assert.equal(outcome.answered, true)
-  assert.deepEqual(outcome.results[0].answers, ['用方案 B，理由如下'])
+  assert.deepEqual(outcome.results[0].answers, ['111'])
+})
+
+test('武装一次性：消费一条后自动解除，后续消息回归普通聊天', async () => {
+  const rig = makeRig({ timeoutMs: 600 })
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: 'c', token: rig.cards[0].token })
+  await sleep(10)
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-a1', text: '第一次回答' })
+  const outcome = await pending
+  assert.deepEqual(outcome.results[0].answers, ['第一次回答'])
+  // 武装已解除：后续消息不再被提问桥消费
+  const textsBefore = rig.texts.length
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-a2', text: '随便聊聊' })
+  await sleep(10)
+  assert.equal(rig.texts.length, textsBefore) // 无回执 = 未被消费
 })
 
 test('「答：」前缀自由文本：直接作为答案提交（无需先点教学按钮）', async () => {

--- a/test/question-card.test.mjs
+++ b/test/question-card.test.mjs
@@ -1,0 +1,172 @@
+// question-card 测试：QQ 提问卡片 + 按钮回调/跳过/自定义文本作答的端到端语义。
+// 覆盖：aq 契约负载 roundtrip、卡片推送落账、按钮选项作答、跳过交还桌面、
+// 自定义教学回执、「答：」前缀自由文本作答、伪造 token 拒绝、非接收会话拦截。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createQuestionBridge } from '../src/questions/router.mjs'
+import { createInboundBus } from '../src/inbound/bus.mjs'
+import { createTokenVault } from '../src/inbound/tokens.mjs'
+import { createStore } from '../src/inbound/store.mjs'
+import { buildQuestionAction, parseQuestionAction } from '../src/inbound/_contract.mjs'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const OPENID_A = 'A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4'
+
+/** 最小装配：真实 bridge/bus/vault/store + 统一契约形状的 qq 假通道。 */
+function makeRig({ timeoutMs = 900 } = {}) {
+  const store = createStore(join(mkdtempSync(join(tmpdir(), 'dsh-notifier-qcard-')), 'state.json'))
+  const vault = createTokenVault({ secret: 'qcard-secret' })
+  const bus = createInboundBus({ allowUsers: [OPENID_A], store, vault })
+  const broadcasts = []
+  const notifier = {
+    channels: ['qq-bot'],
+    notifyAll: async (msg) => { broadcasts.push(msg); return { ok: true, delivered: [], skipped: [], failed: [] } },
+  }
+  const cards = []
+  const texts = []
+  const qqLike = {
+    channel: 'qq',
+    capabilities: { buttons: true },
+    notifyTargets: () => [{ chatId: OPENID_A, userId: OPENID_A }],
+    // 与 qq-gw 实现同契约：捕获入参、回 messageId（按钮构建正确性由 live 验证覆盖）
+    sendQuestionCard: async (payload) => { cards.push(payload); return { messageId: `qm-${cards.length}` } },
+    editResolved: async () => {},
+    sendText: async (chatId, text) => { texts.push({ chatId, text }); return true },
+  }
+  const bridge = createQuestionBridge({
+    bus, vault, store, notifier,
+    interactive: () => [qqLike],
+    logger: { warn: () => {} },
+    config: { timeoutMs },
+  })
+  bridge.attach()
+  const ask = (question = '选哪个方案？', options = [{ label: '方案 A' }, { label: '方案 B' }], multiSelect = false) =>
+    bridge.askQuestions({ questions: [{ question, options, multiSelect }], timeoutMs }, {})
+  /** 模拟 qq-gw INTERACTION → bus.accept 注入提问按钮回调。 */
+  const clickButton = ({ qKey, optIdx, token }, chatId = OPENID_A) => bus.accept({
+    channel: 'qq', userId: OPENID_A, chatId, messageId: `ix-${Math.random().toString(36).slice(2)}`,
+    text: `[提问按钮:${optIdx}] ${qKey}`,
+    questionAction: { qKey, optIdx, token },
+  })
+  return { store, bus, vault, cards, texts, broadcasts, bridge, ask, clickButton }
+}
+
+test('aq 契约负载 roundtrip：qKey 含前缀冒号时中间段完整重组', () => {
+  const parsed = parseQuestionAction(buildQuestionAction('aq:ab12cd34', '0', 'tok-abc'))
+  assert.deepEqual(parsed, { qKey: 'aq:ab12cd34', optIdx: '0', token: 'tok-abc' })
+  assert.equal(parseQuestionAction('aq:x:s'), null) // 少于 4 段：格式不符
+  assert.equal(parseQuestionAction('garbage'), null)
+})
+
+test('卡片推送：sendQuestionCard 收到契约参数并落账 pushedTo；不再重复发编号广播', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  assert.equal(rig.cards.length, 1)
+  const card = rig.cards[0]
+  assert.equal(card.title, '提问：选哪个方案？')
+  assert.deepEqual(card.options, ['方案 A', '方案 B'])
+  assert.equal(card.multiSelect, false)
+  assert.match(String(card.qKey), /^aq:/)
+  assert.ok(String(card.token).length > 10)
+  const row = rig.store.get(card.qKey)
+  assert.equal(row.status, 'pending')
+  assert.equal(row.pushedTo[0].channel, 'qq')
+  assert.equal(rig.broadcasts.length, 0) // 卡片已送达 qq：出站孪生不重复教编号
+  rig.clickButton({ qKey: card.qKey, optIdx: '1', token: card.token })
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['方案 B'])
+})
+
+test('按钮作答：数字下标经验签+来源校验裁决，回执确认', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: '0', token: rig.cards[0].token })
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['方案 A'])
+  assert.equal(outcome.results[0].via, 'qq:button')
+  assert.ok(rig.texts.some((t) => /✅ 已作答：方案 A/.test(t.text)))
+})
+
+test('跳过按钮：立即交还桌面（answered=false, skipped-by-user），绝不代答', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: 's', token: rig.cards[0].token })
+  const outcome = await pending
+  assert.equal(outcome.answered, false)
+  assert.equal(outcome.results[0].reason, 'skipped-by-user')
+  assert.equal(rig.store.get(rig.cards[0].qKey).decision, 'skipped')
+  assert.ok(rig.texts.some((t) => /⏭ 已跳过/.test(t.text)))
+})
+
+test('自定义教学按钮：问题保持待决，回执教「答：」前缀', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: 'c', token: rig.cards[0].token })
+  await sleep(10)
+  assert.ok(rig.texts.some((t) => /✍️ 自定义回答/.test(t.text)))
+  assert.equal(rig.store.get(rig.cards[0].qKey).status, 'pending') // 未被消费
+  // 教学之后按「答：」提交自由文本 → 成为答案
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-custom', text: '答：用方案 B，理由如下' })
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['用方案 B，理由如下'])
+})
+
+test('「答：」前缀自由文本：直接作为答案提交（无需先点教学按钮）', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-t1', text: '答：都行，你定' })
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['都行，你定'])
+  assert.equal(outcome.results[0].via, 'qq:text')
+})
+
+test('裸文本不受影响：非「答：」行首不消费提问、不产生回执', async () => {
+  const rig = makeRig()
+  const pending = rig.ask()
+  await sleep(30)
+  const textsBefore = rig.texts.length
+  rig.bus.accept({ channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: 'm-t2', text: '回答一下：方案 B' })
+  await sleep(10)
+  assert.equal(rig.store.get(rig.cards[0].qKey).status, 'pending') // 保持待决
+  assert.equal(rig.texts.length, textsBefore) // 未产生任何作答回执
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: '0', token: rig.cards[0].token }) // 收尾
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+})
+
+test('伪造 token：验签拒绝，提问保持待决直至超时交还桌面', async () => {
+  const rig = makeRig({ timeoutMs: 600 })
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: '0', token: 'forged-token' })
+  await sleep(10)
+  assert.equal(rig.store.get(rig.cards[0].qKey).status, 'pending')
+  assert.ok(rig.texts.some((t) => /作答失败|校验失败/.test(t.text)))
+  const outcome = await pending
+  assert.equal(outcome.answered, false)
+})
+
+test('非接收会话：chatId 不在 pushedTo 的点击被拦截（跨会话不可操作）', async () => {
+  const rig = makeRig({ timeoutMs: 600 })
+  const pending = rig.ask()
+  await sleep(30)
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: '0', token: rig.cards[0].token }, 'other-chat-id')
+  await sleep(10)
+  assert.equal(rig.store.get(rig.cards[0].qKey).status, 'pending')
+  assert.ok(rig.texts.some((t) => /请到原会话操作/.test(t.text)))
+  rig.clickButton({ qKey: rig.cards[0].qKey, optIdx: '0', token: rig.cards[0].token }) // 正确会话收尾
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+})

--- a/test/question-dual.test.mjs
+++ b/test/question-dual.test.mjs
@@ -1,0 +1,143 @@
+// question-dual 测试：ask_user 双端并行（桌面弹窗 ↔ 远端卡片，先答先算）。
+// 覆盖：桌面抢先（远端卡终结+答案映射）、远端先答（弹窗被 abort）、桌面取消回落、
+// 无服务/关闭并行的旧行为保留、多问批次整批改用桌面答案。
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createQuestionBridge, registerAskUserTool } from '../src/questions/router.mjs'
+import { createInboundBus } from '../src/inbound/bus.mjs'
+import { createTokenVault } from '../src/inbound/tokens.mjs'
+import { createStore } from '../src/inbound/store.mjs'
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const OPENID_A = 'A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4'
+const ARGS = {
+  questions: [{ question: '选哪个？', options: [{ label: '甲' }, { label: '乙' }] }],
+  timeoutMs: 60_000,
+}
+
+function makeDualRig({ parallel = true, userQuestions } = {}) {
+  const store = createStore(join(mkdtempSync(join(tmpdir(), 'dsh-notifier-qdual-')), 'state.json'))
+  const vault = createTokenVault({ secret: 'qdual-secret' })
+  const bus = createInboundBus({ allowUsers: [OPENID_A], store, vault })
+  const notifier = { channels: ['qq-bot'], notifyAll: async () => ({ ok: true, delivered: [], skipped: [], failed: [] }) }
+  const cards = []
+  const cardEdits = []
+  const texts = []
+  const qqLike = {
+    channel: 'qq',
+    capabilities: { buttons: true },
+    notifyTargets: () => [{ chatId: OPENID_A, userId: OPENID_A }],
+    sendQuestionCard: async (payload) => { cards.push(payload); return { messageId: `qm-${cards.length}` } },
+    editResolved: async (_target, text) => { cardEdits.push(text) },
+    sendText: async (_chatId, text) => { texts.push(text); return true },
+  }
+  const bridge = createQuestionBridge({
+    bus, vault, store, notifier,
+    interactive: () => [qqLike],
+    logger: { warn: () => {} },
+    config: { timeoutMs: 60_000 },
+  })
+  bridge.attach()
+  let registeredTool = null
+  const ctx = {
+    tools: { register: (tool) => { registeredTool = tool; return () => {} } },
+    ...(userQuestions !== undefined ? { userQuestions } : {}),
+  }
+  registerAskUserTool(ctx, bridge, { rateLimitPerMinute: 6, defaultTimeoutMs: 300_000, parallel })
+  const clickOption0 = () => bus.accept({
+    channel: 'qq', userId: OPENID_A, chatId: OPENID_A, messageId: `ix-${Math.random().toString(36).slice(2)}`,
+    text: '[提问按钮:0] x',
+    questionAction: { qKey: cards[0].qKey, optIdx: '0', token: cards[0].token },
+  })
+  return { store, bridge, cards, cardEdits, texts, tool: () => registeredTool, clickOption0 }
+}
+
+test('桌面抢先提交：远端待决卡被终结（🖥️ 文案）+ 整批改用桌面答案', async () => {
+  const rig = makeDualRig({
+    userQuestions: { ask: async () => ({ answers: [{ id: 'q1', selected: ['乙'] }] }) },
+  })
+  const outcome = await rig.tool().execute(ARGS, {})
+  assert.equal(outcome.answered, true)
+  assert.equal(outcome.via, 'web')
+  assert.deepEqual(outcome.results[0].answers, ['乙'])
+  assert.ok(rig.cardEdits.some((t) => /🖥️ 已在桌面\/Web 作答/.test(t)))
+})
+
+test('远端先答：QQ 按钮作答生效，桌面弹窗收到 abort 信号', async () => {
+  let aborted = false
+  const rig = makeDualRig({
+    userQuestions: { ask: (req) => new Promise((_resolve, reject) => {
+      // 模拟 apiproxy 真提供方：abort 即拒绝（弹窗被撤）
+      req.signal?.addEventListener('abort', () => { aborted = true; reject(new Error('ASK_ABORTED')) }, { once: true })
+    }) },
+  })
+  const pending = rig.tool().execute(ARGS, {})
+  await sleep(40)
+  rig.clickOption0()
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['甲'])
+  assert.equal(outcome.results[0].via, 'qq:button')
+  assert.equal(aborted, true) // 远端赢 → 撤掉没人理的弹窗
+})
+
+test('桌面被用户关掉：回落远端结论，行为与单端一致', async () => {
+  const rig = makeDualRig({
+    userQuestions: { ask: async () => { throw new Error('ASK_ABORTED') } },
+  })
+  const pending = rig.tool().execute(ARGS, {})
+  await sleep(40)
+  rig.clickOption0()
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['甲'])
+  assert.equal(outcome.dualEnd, undefined) // 实际走的是远端结果
+})
+
+test('无 userQuestions 服务：旧行为逐字节保留', async () => {
+  const rig = makeDualRig({ userQuestions: undefined })
+  const pending = rig.tool().execute(ARGS, {})
+  await sleep(40)
+  rig.clickOption0()
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.deepEqual(outcome.results[0].answers, ['甲'])
+})
+
+test('parallel:false：即使服务在也走单端瀑布', async () => {
+  let asked = false
+  const rig = makeDualRig({
+    parallel: false,
+    userQuestions: { ask: async () => { asked = true; return { answers: [] } } },
+  })
+  const pending = rig.tool().execute(ARGS, {})
+  await sleep(40)
+  rig.clickOption0()
+  const outcome = await pending
+  assert.equal(outcome.answered, true)
+  assert.equal(asked, false) // 原生询问从未被触发
+})
+
+test('多问批次：桌面一次答全 → 全部按桌面答案；后续问题不再外发', async () => {
+  const multiArgs = {
+    questions: [
+      { question: '第一问', options: [{ label: 'A1' }, { label: 'A2' }] },
+      { question: '第二问', options: [{ label: 'B1' }, { label: 'B2' }] },
+    ],
+    timeoutMs: 60_000,
+  }
+  const rig = makeDualRig({
+    userQuestions: { ask: async () => ({ answers: [
+      { id: 'q1', selected: ['A2'] },
+      { id: 'q2', custom: '我就随便说说' },
+    ] }) },
+  })
+  const outcome = await rig.tool().execute(multiArgs, {})
+  assert.equal(outcome.answered, true)
+  assert.equal(rig.cards.length <= 1, true) // 第二问不再外发卡片（旗标短路）
+  assert.deepEqual(outcome.results[0].answers, ['A2'])
+  assert.deepEqual(outcome.results[1].answers, ['我就随便说说']) // custom 自由文本
+})


### PR DESCRIPTION
加了个开关（默认关闭）：打开后QQ和网页同时审批，哪边先点哪边算，另一边再点无效。
QQ官方bot的审批和提问改成了卡片按钮，原有文字消息兜底；

AI生成